### PR TITLE
Add example scripts to documentation

### DIFF
--- a/docs/examples/xarray-2D.ipynb
+++ b/docs/examples/xarray-2D.ipynb
@@ -34,8 +34,8 @@
     "\n",
     "paths = (\n",
     "    'g2vazizi/jet/94875/8000',\n",
-    "    'g2vazizi/jet//94875/8001',\n",
-    "    'g2vazizi/jet//94875/8002',\n",
+    "    'g2vazizi/jet/94875/8001',\n",
+    "    'g2vazizi/jet/94875/8002',\n",
     ")\n",
     "handles = [ImasHandle.from_string(p) for p in paths]"
    ]

--- a/docs/scripts/modify_data.md
+++ b/docs/scripts/modify_data.md
@@ -1,0 +1,7 @@
+## Hello world
+
+```python
+{!../scripts/modify_imas_data.py!}
+```
+
+[Source code](https://github.com/duqtools/duqtools/tree/main/scripts/imas_workflow.py)

--- a/docs/scripts/modify_data.md
+++ b/docs/scripts/modify_data.md
@@ -1,7 +1,0 @@
-## Hello world
-
-```python
-{!../scripts/modify_imas_data.py!}
-```
-
-[Source code](https://github.com/duqtools/duqtools/tree/main/scripts/imas_workflow.py)

--- a/docs/scripts/modify_imas_data.md
+++ b/docs/scripts/modify_imas_data.md
@@ -1,0 +1,7 @@
+## Modify IMAS data
+
+```python
+{!../scripts/modify_imas_data.py!}
+```
+
+[Source code](https://github.com/duqtools/duqtools/tree/main/scripts/modify_imas_data.py)

--- a/docs/scripts/modify_imas_data.md
+++ b/docs/scripts/modify_imas_data.md
@@ -1,5 +1,7 @@
 ## Modify IMAS data
 
+Below is a simple example of how duqtools can be used to modify IMAS data.
+
 ```python
 {!../scripts/modify_imas_data.py!}
 ```

--- a/docs/scripts/plot_with_altair.md
+++ b/docs/scripts/plot_with_altair.md
@@ -1,12 +1,16 @@
 ## Plot with Altair
 
+Below is an example of how to use the duqtools api to plot data with [altair](https://altair-viz.github.io/.).
+
 ```python
 {!../scripts/plot_with_altair.py!}
 ```
 
 [Source code](https://github.com/duqtools/duqtools/tree/main/scripts/plot_with_altair.py)
 
-## Link to notebook for more advanced concatenation with rebasing ##
+The code below shows how to make a plot with [altair](https://altair-viz.github.io/.) for multiple datasets.
+
+For a more advanced example of how to concatenate data, check out the [example notebooks](../../examples/xarray).
 
 ```python
 {!../scripts/plot_with_altair_multi.py!}

--- a/docs/scripts/plot_with_altair.md
+++ b/docs/scripts/plot_with_altair.md
@@ -5,3 +5,11 @@
 ```
 
 [Source code](https://github.com/duqtools/duqtools/tree/main/scripts/plot_with_altair.py)
+
+## Link to notebook for more advanced concatenation with rebasing ##
+
+```python
+{!../scripts/plot_with_altair_multi.py!}
+```
+
+[Source code](https://github.com/duqtools/duqtools/tree/main/scripts/plot_with_altair_multi.py)

--- a/docs/scripts/plot_with_altair.md
+++ b/docs/scripts/plot_with_altair.md
@@ -1,0 +1,7 @@
+## Plot with Altair
+
+```python
+{!../scripts/plot_with_altair.py!}
+```
+
+[Source code](https://github.com/duqtools/duqtools/tree/main/scripts/plot_with_altair.py)

--- a/docs/scripts/plot_with_matplotlib.md
+++ b/docs/scripts/plot_with_matplotlib.md
@@ -1,0 +1,7 @@
+## Plot with Matplotlib
+
+```python
+{!../scripts/plot_with_matplotlib.py!}
+```
+
+[Source code](https://github.com/duqtools/duqtools/tree/main/scripts/plot_with_matplotlib.py)

--- a/docs/scripts/plot_with_matplotlib.md
+++ b/docs/scripts/plot_with_matplotlib.md
@@ -5,3 +5,11 @@
 ```
 
 [Source code](https://github.com/duqtools/duqtools/tree/main/scripts/plot_with_matplotlib.py)
+
+## Link to notebook for more advanced concatenation with rebasing ##
+
+```python
+{!../scripts/plot_with_matplotlib_multi.py!}
+```
+
+[Source code](https://github.com/duqtools/duqtools/tree/main/scripts/plot_with_matplotlib_multi.py)

--- a/docs/scripts/plot_with_matplotlib.md
+++ b/docs/scripts/plot_with_matplotlib.md
@@ -1,12 +1,16 @@
 ## Plot with Matplotlib
 
+Below is an example of how to use the duqtools api to plot data with [matplotlib](https://matplotlib.org/).
+
 ```python
 {!../scripts/plot_with_matplotlib.py!}
 ```
 
 [Source code](https://github.com/duqtools/duqtools/tree/main/scripts/plot_with_matplotlib.py)
 
-## Link to notebook for more advanced concatenation with rebasing ##
+The code below shows how to make a plot with [matplotlib](https://matplotlib.org/) for multiple datasets.
+
+For a more advanced example of how to concatenate data, check out the [example notebooks](../../examples/xarray).
 
 ```python
 {!../scripts/plot_with_matplotlib_multi.py!}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,7 +18,7 @@ nav:
   - Python API:
     - Public API: api.md
     - Operations: operations.md
-  - Examples:
+  - Notebooks:
     - examples/imas_handles.ipynb
     - examples/xarray.ipynb
     - examples/xarray-2D.ipynb

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,7 +24,9 @@ nav:
     - examples/xarray-2D.ipynb
     - examples/xarray-ions.ipynb
   - Scripts:
-    - scripts/modify_data.md
+    - scripts/modify_imas_data.md
+    - scripts/plot_with_altair.md
+    - scripts/plot_with_matplotlib.md
   - Contributing: CONTRIBUTING.md
   - Code of Conduct: CODE_OF_CONDUCT.md
   - 🔗 Source code: https://github.com/duqtools/duqtools

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,6 +23,8 @@ nav:
     - examples/xarray.ipynb
     - examples/xarray-2D.ipynb
     - examples/xarray-ions.ipynb
+  - Scripts:
+    - scripts/modify_data.md
   - Contributing: CONTRIBUTING.md
   - Code of Conduct: CODE_OF_CONDUCT.md
   - 🔗 Source code: https://github.com/duqtools/duqtools

--- a/scripts/modify_imas_data.py
+++ b/scripts/modify_imas_data.py
@@ -1,8 +1,8 @@
 from duqtools.ids._location import ImasHandle
 
-source = ImasHandle(db='jet', shot=92432, user='g2aho', run=1)
+source = ImasHandle(db='jet', shot=94875, user='g2ssmee', run=8000)
 
-target = ImasHandle(db=source.db, shot=source.shot, run=1001)
+target = ImasHandle(db=source.db, shot=source.shot, run=8888)
 
 source.copy_data_to(target)
 

--- a/scripts/plot_with_altair.py
+++ b/scripts/plot_with_altair.py
@@ -1,0 +1,12 @@
+from duqtools.api import ImasHandle, alt_line_chart
+
+handle = ImasHandle.from_string('g2vazizi/jet/94875/8000')
+
+x_var = 'rho_tor_norm'
+y_var = 't_i_ave'
+
+dataset = handle.get_variables(variables=(x_var, y_var))
+
+chart = alt_line_chart(dataset, x=x_var, y=y_var)
+
+chart.save('chart.html', scale_factor=2.0)

--- a/scripts/plot_with_altair_multi.py
+++ b/scripts/plot_with_altair_multi.py
@@ -1,0 +1,23 @@
+import xarray as xr
+
+from duqtools.api import ImasHandle, alt_line_chart
+
+runs = 8000, 8001, 8002
+
+x_var = 'rho_tor_norm'
+y_var = 'zeff'
+
+handles = [
+    ImasHandle(user='g2vazizi', db='jet', shot='94875', run=run)
+    for run in runs
+]
+
+ds_list = (handle.get_variables(variables=(x_var, y_var))
+           for handle in handles)
+
+idx = xr.DataArray(list(runs), dims=['run'])
+dataset = xr.concat(ds_list, idx)
+
+chart = alt_line_chart(dataset, x=x_var, y=y_var)
+
+chart.save('chart.html', scale_factor=2.0)

--- a/scripts/plot_with_matplotlib.py
+++ b/scripts/plot_with_matplotlib.py
@@ -1,0 +1,10 @@
+from duqtools.api import ImasHandle
+
+handle = ImasHandle.from_string('g2vazizi/jet/94875/8000')
+
+x_var = 'rho_tor_norm'
+y_var = 'zeff'
+
+dataset = handle.get_variables(variables=(x_var, y_var))
+
+# MPL stuff

--- a/scripts/plot_with_matplotlib.py
+++ b/scripts/plot_with_matplotlib.py
@@ -1,10 +1,15 @@
+import matplotlib.pyplot as plt
+
 from duqtools.api import ImasHandle
 
 handle = ImasHandle.from_string('g2vazizi/jet/94875/8000')
 
 x_var = 'rho_tor_norm'
 y_var = 'zeff'
+time_var = 'time'
 
-dataset = handle.get_variables(variables=(x_var, y_var))
+dataset = handle.get_variables(variables=(x_var, y_var, time_var))
 
-# MPL stuff
+fig = dataset.plot.scatter(x_var, y_var, hue='time', marker='.')
+
+plt.show()

--- a/scripts/plot_with_matplotlib_multi.py
+++ b/scripts/plot_with_matplotlib_multi.py
@@ -1,0 +1,21 @@
+import pandas as pd
+import xarray as xr
+
+from duqtools.api import ImasHandle
+
+runs = 8000, 8001, 8002
+
+x_var = 'rho_tor_norm'
+y_var = 't_i_ave'
+
+ds_list = []
+
+for run in runs:
+    handle = ImasHandle(user='g2vazizi', db='jet', shot='94875', run=run)
+
+    ds = handle.get_variables(variables=(x_var, y_var))
+    ds_list.append(ds)
+
+dataset = xr.concat(ds_list, pd.Index(runs, name='run'))
+
+# MPL stuff

--- a/scripts/plot_with_matplotlib_multi.py
+++ b/scripts/plot_with_matplotlib_multi.py
@@ -1,21 +1,27 @@
+import matplotlib.pyplot as plt
 import pandas as pd
 import xarray as xr
 
-from duqtools.api import ImasHandle
+from duqtools.api import ImasHandle, standardize_datasets
 
 runs = 8000, 8001, 8002
 
 x_var = 'rho_tor_norm'
 y_var = 't_i_ave'
+time_var = 'time'
 
 ds_list = []
 
 for run in runs:
     handle = ImasHandle(user='g2vazizi', db='jet', shot='94875', run=run)
 
-    ds = handle.get_variables(variables=(x_var, y_var))
+    ds = handle.get_variables(variables=(x_var, y_var, time_var))
     ds_list.append(ds)
+
+ds_list = standardize_datasets(ds_list, grid_var=x_var, time_var=time_var)
 
 dataset = xr.concat(ds_list, pd.Index(runs, name='run'))
 
-# MPL stuff
+fig = dataset.plot.scatter(x_var, y_var, hue='time', col='run', marker='.')
+
+plt.show()

--- a/src/duqtools/_plot_utils.py
+++ b/src/duqtools/_plot_utils.py
@@ -6,6 +6,21 @@ import pandas as pd
 import xarray as xr
 
 
+def _standardize_data(source: Union[pd.DataFrame, xr.Dataset]) -> pd.DataFrame:
+    """Convert Dataset to Dataframe and add required columns for plotting."""
+    if isinstance(source, xr.Dataset):
+        source = source.to_dataframe().reset_index()
+
+    if 'run' not in source:
+        source['run'] = 0
+
+    if 'slider' not in source:
+        _, idx = np.unique(source['time'], return_inverse=True)
+        source['slider'] = idx
+
+    return source
+
+
 def alt_line_chart(source: Union[pd.DataFrame, xr.Dataset], *, x: str,
                    y: str) -> alt.Chart:
     """Generate an altair line chart from a dataframe.
@@ -24,12 +39,7 @@ def alt_line_chart(source: Union[pd.DataFrame, xr.Dataset], *, x: str,
     alt.Chart
         Return an altair chart.
     """
-    if isinstance(source, xr.Dataset):
-        source = source.to_dataframe().reset_index()
-
-    if 'slider' not in source:
-        _, idx = np.unique(source['time'], return_inverse=True)
-        source['slider'] = idx
+    source = _standardize_data(source)
 
     max_y = source[y].max()
     max_slider = source['slider'].max()
@@ -91,12 +101,7 @@ def alt_errorband_chart(source: Union[pd.DataFrame, xr.Dataset], *, x: str,
     alt.Chart
         Return an altair chart.
     """
-    if isinstance(source, xr.Dataset):
-        source = source.to_dataframe().reset_index()
-
-    if 'slider' not in source:
-        _, idx = np.unique(source['time'], return_inverse=True)
-        source['slider'] = idx
+    source = _standardize_data(source)
 
     max_y = source[y].max()
     max_slider = source['slider'].max()

--- a/src/duqtools/api.py
+++ b/src/duqtools/api.py
@@ -4,6 +4,7 @@ Functions:
 
 - [rebase_on_grid][duqtools.api.rebase_on_grid]
 - [rebase_on_time][duqtools.api.rebase_on_time]
+- [standardize_datasets][duqtools.api.standardize_datasets]
 
 Data classes:
 
@@ -18,12 +19,14 @@ Plotting:
 """
 
 from ._plot_utils import alt_errorband_chart, alt_line_chart
-from .ids import IDSMapping, ImasHandle, rebase_on_grid, rebase_on_time
+from .ids import (IDSMapping, ImasHandle, rebase_on_grid, rebase_on_time,
+                  standardize_datasets)
 from .schema import IDSVariableModel as Variable
 
 __all__ = [
     'rebase_on_grid',
     'rebase_on_time',
+    'standardize_datasets',
     'ImasHandle',
     'IDSMapping',
     'Variable',

--- a/src/duqtools/ids/__init__.py
+++ b/src/duqtools/ids/__init__.py
@@ -4,8 +4,8 @@ from ._handle import ImasHandle
 from ._imas import imas_mocked
 from ._mapping import IDSMapping
 from ._merge import merge_data
-from ._rebase import (rebase_on_grid, rebase_on_time, standardize_grid,
-                      standardize_time)
+from ._rebase import (rebase_on_grid, rebase_on_time, standardize_datasets,
+                      standardize_grid, standardize_time)
 
 logger = logging.getLogger(__name__)
 
@@ -15,6 +15,7 @@ __all__ = [
     'merge_data',
     'rebase_on_grid',
     'rebase_on_time',
+    'standardize_datasets',
     'standardize_grid',
     'standardize_time',
     'imas_mocked',

--- a/src/duqtools/ids/_rebase.py
+++ b/src/duqtools/ids/_rebase.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Union
+from typing import List, Sequence, Union
 
 import numpy as np
 import xarray as xr
@@ -74,6 +74,24 @@ def standardize_grid(ds: xr.Dataset,
 
 def rebase_on_grid(ds: xr.Dataset, *, coord_dim: str,
                    new_coords: np.ndarray) -> xr.Dataset:
+    """Rebase (interpolate) the coordinate dimension to the new coordinates.
+
+    Thin wrapper around `xarray.Dataset.interp`.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        Source dataset
+    coord_dim : str
+        Name of the grid dimension (i.e. grid variable).
+    new_coords : np.ndarray
+        The coordinates to interpolate to
+
+    Returns
+    -------
+    xr.Dataset
+        Rebased dataset
+    """
     return ds.interp(coords={coord_dim: new_coords},
                      kwargs={'fill_value': 'extrapolate'})
 
@@ -82,4 +100,91 @@ def rebase_on_time(ds: xr.Dataset,
                    *,
                    time_dim='time',
                    new_coords: np.ndarray) -> xr.Dataset:
+    """Rebase (interpolate) the time dimension to the new coordinates.
+
+    Thin wrapper around `xarray.Dataset.interp`.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        Source dataset
+    time_dim : str
+        Name of the time dimension (i.e. time variable).
+    new_coords : np.ndarray
+        The coordinates to interpolate to
+
+    Returns
+    -------
+    xr.Dataset
+        Rebased dataset
+    """
     return rebase_on_grid(ds, coord_dim=time_dim, new_coords=new_coords)
+
+
+def standardize_datasets(
+    datasets: Sequence[xr.Dataset],
+    *,
+    grid_var: str = 'rho_tor_norm',
+    grid_placeholder: str = 'x',
+    time_var: str = 'time',
+    reference_grid_idx: int = 0,
+    reference_dataset: int = 0,
+) -> List[xr.Dataset]:
+    """Standardize list of datasets by applying standard rebase operations.
+
+    Applies, in sequence:
+    1. `standardize_grid`
+    2. `rebase_on_grid`
+    3. `rebase_on_time`
+
+    Parameters
+    ----------
+    datasets : Sequence[xr.Dataset]
+        List of source datasets
+    grid_var : str, optional
+        Name of the grid dimension (i.e. grid variable)
+    grid_placeholder : str, optional
+        Name of the placeholder for the grid dimension
+    time_var : str, optional
+        Name of the time dimension (i.e. time variable)
+    reference_grid_idx : int, optional
+        For each dataset, the data of the grid with this index along the time dimension
+        will be used as the new coordinate for the grid dimension. Data variables will
+        be rebased onto these coordinates if necessary.
+
+        Maps to `new_dim_data` in `standardize_grid`.
+    reference_dataset : int, optional
+        The dataset with this index will be used as the reference for rebasing.
+        The grid and time coordinates of the other datasets will be rebased
+        to the reference.
+
+    Returns
+    -------
+    List[xr.Dataset]
+        List of output datasets
+    """
+    datasets = [
+        standardize_grid(
+            ds,
+            new_dim=grid_var,
+            old_dim=grid_placeholder,
+            new_dim_data=reference_grid_idx,
+            group=time_var,
+        ) for ds in datasets
+    ]
+
+    reference_grid = datasets[reference_dataset][grid_var].data
+
+    datasets = [
+        rebase_on_grid(ds, coord_dim=grid_var, new_coords=reference_grid)
+        for ds in datasets
+    ]
+
+    reference_time = datasets[reference_dataset][time_var].data
+
+    datasets = [
+        rebase_on_time(ds, time_dim=time_var, new_coords=reference_time)
+        for ds in datasets
+    ]
+
+    return datasets


### PR DESCRIPTION
This PR adds some example scripts to the documentation that show some basic tasks using the API.

Closes #310

### Todo

- [x] Load and modify some data (re-use old example script -> [link](https://github.com/duqtools/duqtools/blob/main/scripts/imas_workflow.py))
- [x] Load and plot some data with altair
- [x] Add altair multi handle example (same page)
- [x] Load and plot some data with xarray->matplotlib
- [x] Add mpl multi handle example (same page)
- [x] Add a bit of documentation to md files about scripts