### PR TITLE
Allow empty variables to be skipped when loading xarray data

### DIFF
--- a/src/duqtools/config/_variables.py
+++ b/src/duqtools/config/_variables.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import os
 from pathlib import Path
-from typing import Sequence, Union
+from typing import List, Sequence, Union
 
 from importlib_resources import files
 
@@ -76,7 +76,9 @@ class VariableConfigLoader:
         return files('duqtools.data') / VAR_FILENAME
 
 
-def lookup_vars(variables: Sequence[Union[str, IDSVariableModel]]):
+def lookup_vars(
+    variables: Sequence[Union[str,
+                              IDSVariableModel]]) -> List[IDSVariableModel]:
     """Helper function to look up a bunch of variables.
 
     If str, look up the variable from the `var_lookup` Else check if the

--- a/src/duqtools/ids/_handle.py
+++ b/src/duqtools/ids/_handle.py
@@ -150,26 +150,26 @@ class ImasHandle(ImasBaseModel):
 
         return data
 
-    def get(self, ids: str = 'core_profiles', **kwargs) -> IDSMapping:
+    def get(self, ids: str = 'core_profiles') -> IDSMapping:
         """Map the data to a dict-like structure.
 
         Parameters
         ----------
         ids : str, optional
             Name of profiles to open
-        **kwargs
-            These parameters are passed to initialize `IDSMapping`.
 
         Returns
         -------
         IDSMapping
         """
         raw_data = self.get_raw_data(ids)
-        return IDSMapping(raw_data, **kwargs)
+        return IDSMapping(raw_data)
 
     def get_variables(
-            self, variables: Sequence[Union[str,
-                                            IDSVariableModel]]) -> xr.Dataset:
+        self,
+        variables: Sequence[Union[str, IDSVariableModel]],
+        **kwargs,
+    ) -> xr.Dataset:
         """Get variables from data set.
 
         This function looks up the data location from the
@@ -184,6 +184,8 @@ class ImasHandle(ImasBaseModel):
         -------
         ds : xarray
             The data in `xarray` format.
+        **kwargs
+            These keyword arguments are passed to `IDSMapping.to_xarray()`
 
         Raises
         ------
@@ -200,9 +202,9 @@ class ImasHandle(ImasBaseModel):
 
         ids = var_models[0].ids
 
-        data_map = self.get(ids, exclude_empty=True)
+        data_map = self.get(ids)
 
-        ds = data_map.to_xarray(variables=var_models)
+        ds = data_map.to_xarray(variables=var_models, **kwargs)
 
         return ds
 

--- a/tests/ids/idsmapping_sample_data.py
+++ b/tests/ids/idsmapping_sample_data.py
@@ -9,18 +9,21 @@ class profile_t0:
     grid = np.arange(10.0) * 1
     variable = grid**2
     val = 1
+    empty = np.array([])
 
 
 class profile_t1:
     grid = np.arange(10.0) * 2
     variable = grid**2
     val = 2
+    empty = np.array([])
 
 
 class profile_t2:
     grid = np.arange(10.0) * 3
     variable = grid**2
     val = 3
+    empty = np.array([])
 
 
 class nested_profile_t0:

--- a/tests/ids/test_xarray_interface.py
+++ b/tests/ids/test_xarray_interface.py
@@ -343,3 +343,31 @@ def test_2d_ion(sample_data, expected_dataset_2d_ion):
 
     dataset = sample_data.to_xarray(variables=variables)
     xr.testing.assert_equal(dataset, expected_dataset_2d_ion)
+
+
+def test_empty_var_ok(sample_data):
+    from duqtools.ids._mapping import EmptyVarError
+
+    EmptyVar = Variable(ids='core_profiles',
+                        path='profiles_1d/*/empty',
+                        dims=('time', 'x'),
+                        name='empty')
+
+    with pytest.raises(EmptyVarError):
+        sample_data.to_xarray(variables=(EmptyVar, ), empty_var_ok=False)
+
+    dataset = sample_data.to_xarray(variables=(EmptyVar, ), empty_var_ok=True)
+
+    empty = {'coords': {}, 'attrs': {}, 'dims': {}, 'data_vars': {}}
+    assert dataset.to_dict() == empty
+
+
+def test_raise_on_non_existant(sample_data):
+    NonExistantVar = Variable(ids='core_profiles',
+                              path='profiles_1d/*/does/not/exist',
+                              dims=('time', 'x'),
+                              name='does-not-exist')
+
+    with pytest.raises(KeyError):
+        sample_data.to_xarray(variables=(NonExistantVar, ), skip_empty=True)
+        sample_data.to_xarray(variables=(NonExistantVar, ), skip_empty=False)


### PR DESCRIPTION
This PR adds a `empty_var_ok` toggle to `ImasHandle.get_variables()` / `IDSMapping.to_xarray()` to allow empty variables to be skipped if they do not exist in a dataset. Handling the missing data needs to be handled by the user afterwards or through some [`xr.concat` magic](https://docs.xarray.dev/en/stable/generated/xarray.concat.html).

This PR also improves the error message, and now raises if you attempt to load empty data.

Closes #353
Closes #314