### PR TITLE
Add explicit queued versions of `ImasHandle.delete()` and `merge_data()`

### DIFF
--- a/src/duqtools/cleanup.py
+++ b/src/duqtools/cleanup.py
@@ -56,10 +56,10 @@ def cleanup(out, force, **kwargs):
         data_in = ImasHandle.parse_obj(run.data_in)
         data_out = ImasHandle.parse_obj(run.data_out)
 
-        data_in.delete()
+        data_in.queue_delete()
 
         if out:
-            data_out.delete()
+            data_out.queue_delete()
         else:
             op_queue.add_no_op(description='NOT Removing',
                                extra_description=f'{data_out}')

--- a/src/duqtools/create.py
+++ b/src/duqtools/create.py
@@ -228,7 +228,7 @@ def recreate(*, runs, **kwargs):
         model.data_in = ImasHandle.parse_obj(model.data_in)
         model.data_out = ImasHandle.parse_obj(model.data_out)
 
-        model.data_in.delete()
+        model.data_in.queue_delete()
         remove_run(model)
 
         run_models.append(model)

--- a/src/duqtools/ids/__init__.py
+++ b/src/duqtools/ids/__init__.py
@@ -3,7 +3,7 @@ import logging
 from ._handle import ImasHandle
 from ._imas import imas_mocked
 from ._mapping import IDSMapping
-from ._merge import merge_data
+from ._merge import merge_data, queue_merge_data
 from ._rebase import (rebase_on_grid, rebase_on_time, standardize_datasets,
                       standardize_grid, standardize_time)
 
@@ -19,4 +19,5 @@ __all__ = [
     'standardize_grid',
     'standardize_time',
     'imas_mocked',
+    'queue_merge_data',
 ]

--- a/src/duqtools/ids/_handle.py
+++ b/src/duqtools/ids/_handle.py
@@ -115,9 +115,12 @@ class ImasHandle(ImasBaseModel):
             raise OSError(f'Failed to copy {self}') from err
 
     @add_to_op_queue('Removing ids', '{self}')
+    def queue_delete(self):
+        """Queued version of `ImasHandle.delete()`."""
+        return self.delete()
+
     def delete(self):
         """Remove data from entry."""
-
         # ERASE_PULSE operation is yet supported by IMAS as of June 2022
         path = self.path()
         for suffix in SUFFIXES:

--- a/src/duqtools/ids/_merge.py
+++ b/src/duqtools/ids/_merge.py
@@ -27,6 +27,11 @@ def raise_if_ids_inconsistent(*variables: IDSVariableModel):
 
 
 @add_to_op_queue('Merge', '{target}')
+def queue_merge_data(*args, **kwargs):
+    """Queued version of `merge_data()`."""
+    return merge_data(*args, **kwargs)
+
+
 def merge_data(
     source_data: Dict[str, ImasHandle],
     target: ImasHandle,

--- a/src/duqtools/merge.py
+++ b/src/duqtools/merge.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 
 from .config import cfg
-from .ids import ImasHandle, merge_data
+from .ids import ImasHandle, queue_merge_data
 from .utils import read_imas_handles_from_file
 
 logger = logging.getLogger(__name__)
@@ -23,8 +23,8 @@ def merge(**kwargs):
 
         template.copy_data_to(target)
 
-        merge_data(source_data=handles,
-                   target=target,
-                   time_var=step.time_variable,
-                   grid_var=step.grid_variable,
-                   data_vars=step.data_variables)
+        queue_merge_data(source_data=handles,
+                         target=target,
+                         time_var=step.time_variable,
+                         grid_var=step.grid_variable,
+                         data_vars=step.data_variables)


### PR DESCRIPTION
This PR makes queued versions of some functions that could be used in an interactive mode: `ImasHandle.delete()` and `merge_data()`.

Closes #381