### PR TITLE
Add button to download charts to dashboard

### DIFF
--- a/src/duqtools/_plot_utils.py
+++ b/src/duqtools/_plot_utils.py
@@ -55,7 +55,11 @@ def alt_line_chart(source: Union[pd.DataFrame, xr.Dataset], *, x: str,
 
     chart = alt.Chart(source).mark_line().encode(
         x=f'{x}:Q',
-        y=alt.Y(f'{y}:Q', scale=alt.Scale(domain=(0, max_y))),
+        y=alt.Y(
+            f'{y}:Q',
+            scale=alt.Scale(domain=(0, max_y)),
+            axis=alt.Axis(format='.4~g'),
+        ),
         color=alt.Color('run:N'),
         tooltip='run',
     ).add_selection(select_step).transform_filter(select_step).interactive()
@@ -114,7 +118,11 @@ def alt_errorband_chart(source: Union[pd.DataFrame, xr.Dataset], *, x: str,
 
     line = alt.Chart(source).mark_line().encode(
         x=f'{x}:Q',
-        y=alt.Y(f'mean({y}):Q', scale=alt.Scale(domain=(0, max_y))),
+        y=alt.Y(
+            f'mean({y}):Q',
+            scale=alt.Scale(domain=(0, max_y)),
+            axis=alt.Axis(format='.4~g'),
+        ),
         color=alt.Color('tstep:N'),
     ).add_selection(select_step).transform_filter(select_step).interactive()
 

--- a/src/duqtools/data/dash/dash.py
+++ b/src/duqtools/data/dash/dash.py
@@ -64,7 +64,7 @@ for y_key in y_keys:
 
     st.altair_chart(chart, use_container_width=True)
 
-    if st.button('Save this chart'):
+    if st.button('Save this chart', key=f'download_{x_key}-{y_key}'):
         fname = f'chart_{x_key}-{y_key}.html'
         chart.save(fname)
-        st.write(f'✔️ Wrote chart to "{fname}"')
+        st.success(f'✔️ Wrote chart to "{fname}"')

--- a/src/duqtools/data/dash/dash.py
+++ b/src/duqtools/data/dash/dash.py
@@ -63,3 +63,8 @@ for y_key in y_keys:
         chart = alt_line_chart(source, x=x_key, y=y_key)
 
     st.altair_chart(chart, use_container_width=True)
+
+    if st.button('Save this chart'):
+        fname = f'chart_{x_key}-{y_key}.html'
+        chart.save(fname)
+        st.write(f'✔️ Wrote chart to "{fname}"')

--- a/src/duqtools/data/dash/dash.py
+++ b/src/duqtools/data/dash/dash.py
@@ -31,7 +31,13 @@ with st.expander('Click to show runs'):
 with st.sidebar:
     ids_options = get_ids_options()
 
-    ids = st.selectbox('Select IDS', ids_options, index=0)
+    default_ids = ids_options.index('core_profiles')
+
+    ids = st.selectbox('Select IDS', ids_options, index=default_ids)
+
+    if ids != 'core_profiles':
+        st.error('IDS other than "core_profiles" currently not supported.')
+        st.stop()
 
     var_options = get_var_options(ids=ids)
 


### PR DESCRIPTION
This PR adds a button to download the html for a chart from the dashboard. Note that a png/svg can already be downloaded from the widget directly.

Closes #409 