### PR TITLE
Update flake8 repo in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,8 +37,8 @@ repos:
     rev: 'v1.5.0'
     hooks:
       - id: docformatter
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: '3.9.2'
+  - repo: https://github.com/PyCQA/flake8
+    rev: '5.0.4'
     hooks:
       - id: flake8
   - repo: https://github.com/pre-commit/mirrors-mypy


### PR DESCRIPTION
The old repo was out of date causing `AttributeError`s.

See: https://github.com/PyCQA/flake8/issues/1701