### PR TITLE
Refactor common options parser to make it re-usable

### DIFF
--- a/src/duqtools/init.py
+++ b/src/duqtools/init.py
@@ -13,12 +13,12 @@ else:
 logger = logging.getLogger(__name__)
 
 
-def init(*, config: str, force: bool, **kwargs):
+def init(*, out_file: str, force: bool, **kwargs):
     """Initialize a brand new config file with all the default values.
 
     Parameters
     ----------
-    config : str
+    out : str
         Filename of the config.
     force : bool
         Overwrite config if it already exists.
@@ -32,7 +32,7 @@ def init(*, config: str, force: bool, **kwargs):
     """
     src = files('duqtools.data') / 'duqtools.yaml'
 
-    config_filepath = Path(config)
+    config_filepath = Path(out_file)
 
     if config_filepath.exists() and not force:
         raise RuntimeError(


### PR DESCRIPTION
For #423 I refactored the common options parse so that parts may be re-used in other sections of the code. It also means we do not have to give _all_ common options, but we can be selective for some cli tools that do not need all options.