### PR TITLE
merge --all

### DIFF
--- a/docs/gendocs.py
+++ b/docs/gendocs.py
@@ -16,8 +16,8 @@ from duqtools.schema import (ARange, IDSOperationDim, IDSVariableModel,
                              LinSpace, OperationDim)
 from duqtools.schema._jetto import JsetField, NamelistField
 from duqtools.schema.cli import (ConfigModel, CreateConfigModel,
-                                 MergeConfigModel, MergeStep,
-                                 StatusConfigModel, SubmitConfigModel)
+                                 MergeConfigModel, StatusConfigModel,
+                                 SubmitConfigModel)
 from duqtools.schema.data_location import DataLocation
 from duqtools.system import DummySystem
 
@@ -44,7 +44,6 @@ objects = {
     NamelistField,
     LinSpace,
     MergeConfigModel,
-    MergeStep,
     OperationDim,
     StatusConfigModel,
     SubmitConfigModel,

--- a/docs/templates/template_merge.md
+++ b/docs/templates/template_merge.md
@@ -28,12 +28,9 @@ merge:
     db: jet
     run: 9999
     shot: 94785
-  plan:
-  - data_variables:
+  variables:
     - t_i_ave
     - zeff
-    grid_variable: rho_tor_norm
-    time_variable: time
   template:
     db: jet
     run: 1
@@ -67,31 +64,3 @@ output:
 !!! note
 
     Although the user can be specified for the output location, it is best left blank. In this case, the current user is filled in automatically and you will not run into issues with write permissions.
-
-
-For example:
-
-```yaml title="duqtools.yaml"
-template:
-  user: g2ssmee
-  db: jet
-  shot: 91234
-  run: 1
-output:
-  db: jet
-  shot: 91234
-  run: 100
-```
-
-For example:
-
-```yaml title="duqtools.yaml"
-variables:
-  - t_i_ave
-  - zeff
-```
-
-
-!!! note
-
-    In the current version of duqtools, the *time* coordinate variable must be specified here, even though it won't be merged. This will change in a future version of duqtools.

--- a/docs/templates/template_merge.md
+++ b/docs/templates/template_merge.md
@@ -69,15 +69,6 @@ output:
     Although the user can be specified for the output location, it is best left blank. In this case, the current user is filled in automatically and you will not run into issues with write permissions.
 
 
-## Merge plan
-
-{{ schema_MergeStep['description'] }}
-
-{% for name, prop in schema_MergeStep['properties'].items() %}
-`{{ name }}`
-: {{ prop['description'] }}
-{% endfor %}
-
 For example:
 
 ```yaml title="duqtools.yaml"
@@ -95,10 +86,7 @@ output:
 For example:
 
 ```yaml title="duqtools.yaml"
-plan:
-- grid_variable: rho_tor_norm
-  variables:
-  - time
+variables:
   - t_i_ave
   - zeff
 ```

--- a/src/duqtools/cli.py
+++ b/src/duqtools/cli.py
@@ -384,12 +384,9 @@ def cli_dash(**kwargs):
 @common_options(*all_options)
 def cli_merge(**kwargs):
     """Merge data sets with error propagation."""
-    from .merge import merge, merge_all
+    from .merge import merge
     with op_queue_context():
-        if kwargs['all']:
-            merge_all(**kwargs)
-        else:
-            merge(**kwargs)
+        merge(**kwargs)
 
 
 @cli.command('list-variables')

--- a/src/duqtools/cli.py
+++ b/src/duqtools/cli.py
@@ -380,7 +380,7 @@ def cli_dash(**kwargs):
 
 
 @cli.command('merge')
-@click.option('--all', is_flag=True, help='Try to merge all known variables.')
+@click.option('--all', 'merge_all', is_flag=True, help='Try to merge all known variables.')
 @common_options(*all_options)
 def cli_merge(**kwargs):
     """Merge data sets with error propagation."""

--- a/src/duqtools/cli.py
+++ b/src/duqtools/cli.py
@@ -380,12 +380,16 @@ def cli_dash(**kwargs):
 
 
 @cli.command('merge')
+@click.option('--all', is_flag=True, help='Try to merge all known variables.')
 @common_options(*all_options)
 def cli_merge(**kwargs):
     """Merge data sets with error propagation."""
-    from .merge import merge
+    from .merge import merge, merge_all
     with op_queue_context():
-        merge(**kwargs)
+        if kwargs['all']:
+            merge_all(**kwargs)
+        else:
+            merge(**kwargs)
 
 
 @cli.command('list-variables')

--- a/src/duqtools/data/dash/pages/1_merge.py
+++ b/src/duqtools/data/dash/pages/1_merge.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pandas as pd
 import streamlit as st
 
+from duqtools.config import var_lookup
 from duqtools.ids import ImasHandle, merge_data
 from duqtools.utils import read_imas_handles_from_file
 
@@ -110,9 +111,13 @@ with st.form('merge_form'):
     submitted = st.form_submit_button('Save')
 
     if submitted:
+        merge_vars = [var_lookup[key] for key in y_keys]
+
         template.copy_data_to(target)
 
-        merge_data(source_data=handles, target=target, **variables)
+        merge_data(handles=handles.values(),
+                   target=target,
+                   variables=merge_vars)
 
         st.success('Success!')
         st.balloons()

--- a/src/duqtools/data/duqtools.yaml
+++ b/src/duqtools/data/duqtools.yaml
@@ -33,12 +33,9 @@ merge:
     db: jet
     run: 9999
     shot: 94785
-  plan:
-  - data_variables:
+  variables:
     - t_i_ave
     - zeff
-    grid_variable: rho_tor_norm
-    time_variable: time
 status:
   in_file: jetto.in
   msg_completed: 'Status : Completed successfully'

--- a/src/duqtools/data/variables.yaml
+++ b/src/duqtools/data/variables.yaml
@@ -60,11 +60,11 @@
   path: profiles_1d/*/ion/*/pressure
   dims: [time, ion, $rho_tor_norm]
   type: IDS-variable
-- name: n_n
-  ids: core_profiles
-  path: profiles_1d/*/neutral/*/density
-  dims: [time, neutral, $rho_tor_norm]
-  type: IDS-variable
+#- name: n_n
+#  ids: core_profiles
+#  path: profiles_1d/*/neutral/*/density
+#  dims: [time, neutral, $rho_tor_norm]
+#  type: IDS-variable
 - name: j_tot
   ids: core_profiles
   path: profiles_1d/*/j_total

--- a/src/duqtools/data/variables.yaml
+++ b/src/duqtools/data/variables.yaml
@@ -60,11 +60,11 @@
   path: profiles_1d/*/ion/*/pressure
   dims: [time, ion, $rho_tor_norm]
   type: IDS-variable
-#- name: n_n
-#  ids: core_profiles
-#  path: profiles_1d/*/neutral/*/density
-#  dims: [time, neutral, $rho_tor_norm]
-#  type: IDS-variable
+- name: n_n
+  ids: core_profiles
+  path: profiles_1d/*/neutral/*/density
+  dims: [time, neutral, $rho_tor_norm]
+  type: IDS-variable
 - name: j_tot
   ids: core_profiles
   path: profiles_1d/*/j_total

--- a/src/duqtools/ids/__init__.py
+++ b/src/duqtools/ids/__init__.py
@@ -3,8 +3,9 @@ import logging
 from ._handle import ImasHandle
 from ._imas import imas_mocked
 from ._mapping import IDSMapping
-from ._merge import merge_data, queue_merge_data
-from ._rebase import (rebase_on_grid, rebase_on_time, standardize_grid,
+from ._merge import merge_data
+from ._rebase import (rebase_all_coords, rebase_on_grid, rebase_on_time,
+                      squash_placeholders, standardize_grid,
                       standardize_grid_and_time, standardize_time)
 
 logger = logging.getLogger(__name__)
@@ -15,9 +16,10 @@ __all__ = [
     'merge_data',
     'rebase_on_grid',
     'rebase_on_time',
+    'rebase_all_coords',
     'standardize_grid_and_time',
     'standardize_grid',
     'standardize_time',
+    'squash_placeholders',
     'imas_mocked',
-    'queue_merge_data',
 ]

--- a/src/duqtools/ids/_mapping.py
+++ b/src/duqtools/ids/_mapping.py
@@ -386,10 +386,9 @@ class IDSMapping(Mapping):
             self._write_back(data[index], path, *remaining)
 
     def write_back(self, variable: str, data: xr.DataArray) -> None:
-        """write_back data, give the data, and the variable path, with.
-
-        * denoting the dimensions, and it will write it to the correct
-        locations
+        """write_back data, give the data, and the variable path, where `*`
+        denotes the dimensions. This function will figure out how to write it
+        back to the IDS.
 
         Parameters
         ----------

--- a/src/duqtools/ids/_mapping.py
+++ b/src/duqtools/ids/_mapping.py
@@ -34,7 +34,7 @@ def insert_re_caret_dollar(string: str) -> str:
 
 def replace_index_str(string: str) -> str:
     """Replaces template string with regex digit matching."""
-    return string.replace(INDEX_STR, r'(?P<idx>\d+)')
+    return string.replace(INDEX_STR, r'(\d+)')
 
 
 class IDSMapping(Mapping):

--- a/src/duqtools/ids/_merge.py
+++ b/src/duqtools/ids/_merge.py
@@ -14,7 +14,7 @@ from ._rebase import rebase_all_coords, squash_placeholders
 def merge_data(
     handles: Sequence[ImasHandle],
     target: ImasHandle,
-    _variables: List[IDSVariableModel],
+    variables: List[IDSVariableModel],
 ):
     """merge_data merges the data from the handles to the target, only merges
     over the listed variables, coordination variables are never overwritten,
@@ -31,7 +31,7 @@ def merge_data(
     """
 
     # make sure we do not mess up input arguments
-    variables = _variables.copy()
+    variables = variables.copy()
 
     # Sometimes, dimensions are not yet included,
     # We can safely include them into the variables manually, as they are

--- a/src/duqtools/ids/_merge.py
+++ b/src/duqtools/ids/_merge.py
@@ -1,78 +1,84 @@
-from typing import Dict, Sequence
+from typing import List, Sequence
 
 import xarray as xr
 
 from ..config import var_lookup
 from ..operations import add_to_op_queue
 from ..schema import IDSVariableModel
+from ..utils import groupby
 from ._handle import ImasHandle
-from ._rebase import rebase_on_grid, rebase_on_time
-
-
-def raise_if_ids_inconsistent(*variables: IDSVariableModel):
-    idss = {var.ids for var in variables}
-    if len(idss) != 1:
-        raise ValueError('Variables must have the same IDS, '
-                         f'got {len(idss)} different values: {idss}')
+from ._rebase import rebase_all_coords, squash_placeholders
 
 
 @add_to_op_queue('Merge', '{target}')
 def merge_data(
-    source_data: Dict[str, ImasHandle],
+    handles: Sequence[ImasHandle],
     target: ImasHandle,
-    time_var: str,
-    grid_var: str,
-    data_vars: Sequence[str],
+    _variables: List[IDSVariableModel],
 ):
-    time_var = var_lookup[time_var]
-    grid_var = var_lookup[grid_var]
-    data_vars = [var_lookup[data_var] for data_var in data_vars]
+    """merge_data merges the data from the handles to the target, only merges
+    over the listed variables, coordination variables are never overwritten,
+    and data is rebased according to the target coordination variable.
 
-    raise_if_ids_inconsistent(time_var, grid_var, *data_vars)
+    Parameters
+    ----------
+    handles : Sequence[ImasHandle]
+        handles
+    target : ImasHandle
+        target
+    variables : Sequence[IDSVariableModel]
+        variables
+    """
 
-    TIME_DIM = time_var.name
-    GRID_DIM = grid_var.name
-    RUN_DIM = 'run'
-    ids = grid_var.ids
+    # make sure we do not mess up input arguments
+    variables = _variables.copy()
 
-    variables = [time_var, grid_var, *data_vars]
+    # Sometimes, dimensions are not yet included,
+    # We can safely include them into the variables manually, as they are
+    # automatically transformed into coordinates, and therefore not written back
+    variable_dict = {variable.name: variable for variable in variables}
+    for variable in variables:
+        for dim in variable.dims:
+            # TODO time should also be $ prefixed, remove the `or time` when fixed
+            if not (dim.startswith('$') or dim.startswith('time')):
+                continue
+            name = dim.lstrip('$')
+            if name not in variable_dict.keys():
+                variables.append(var_lookup[name])
+                variable_dict[name] = variables[-1]
 
-    target_data_map = target.get(ids)
+    # Get all known variables per ids
+    grouped_ids_vars = groupby(variables, keyfunc=lambda var: var.ids)
 
-    grid_dim_data = target_data_map.get_at_index(grid_var, 0)
-    time_dim_data = target_data_map[time_var.path]
+    for ids_name, variables in grouped_ids_vars.items():
 
-    datasets = []
-    for run, handle in source_data.items():
-        ds = handle.get_variables(variables=variables)
-        datasets.append(ds)
+        # Get all data, and rebase it
+        idss = [handle.get(ids_name) for handle in handles]  # type: ignore
 
-    datasets = [
-        rebase_on_grid(ds, coord_dim=GRID_DIM, new_coords=grid_dim_data)
-        for ds in datasets
-    ]
+        target_ids = target.get(ids_name)  # type: ignore
+        target_data = target_ids.to_xarray(variables=variables,
+                                           empty_var_ok=True)
+        target_data = squash_placeholders(target_data)
 
-    datasets = [
-        rebase_on_time(ds, time_dim=TIME_DIM, new_coords=time_dim_data)
-        for ds in datasets
-    ]
+        ids_data = [
+            ids.to_xarray(
+                variables=variables,
+                empty_var_ok=True,
+            ) for ids in idss
+        ]
+        ids_data = [squash_placeholders(data) for data in ids_data]
 
-    run_data = xr.concat(datasets, RUN_DIM)
+        ids_data = rebase_all_coords(ids_data, target_data)
 
-    means = run_data.mean(dim=RUN_DIM)
-    stdevs = run_data.std(dim=RUN_DIM)
+        ids_data = xr.concat(ids_data, 'handle')
 
-    for var in data_vars:
-        if var.name not in run_data.data_vars:
-            continue
+        # Now we have to get the stddeviations
+        mean_data = ids_data.mean(dim='handle')
+        std_data = ids_data.std(dim='handle')
 
-        for i, time in enumerate(run_data.time):
-            mean = means.isel({TIME_DIM: i})[var.name].data
-            stdev = stdevs.isel({TIME_DIM: i})[var.name].data
-
-            target_data_map.set_at_index(var.path, value=mean, index=i)
-            target_data_map.set_at_index(var.path + '_error_upper',
-                                         value=mean + stdev,
-                                         index=i)
-
-    target_data_map.sync(target)
+        # Then, write it back to target
+        for name in ids_data.data_vars.keys():
+            target_ids.write_back(variable_dict[name].path, mean_data[name])
+            target_ids.write_back(variable_dict[name].path + '_error_upper',
+                                  std_data[name])
+        target_ids.sync(target)

--- a/src/duqtools/ids/_merge.py
+++ b/src/duqtools/ids/_merge.py
@@ -43,7 +43,7 @@ def merge_data(
             if not (dim.startswith('$') or dim.startswith('time')):
                 continue
             name = dim.lstrip('$')
-            if name not in variable_dict.keys():
+            if name not in variable_dict:
                 variables.append(var_lookup[name])
                 variable_dict[name] = variables[-1]
 

--- a/src/duqtools/ids/_merge.py
+++ b/src/duqtools/ids/_merge.py
@@ -59,7 +59,7 @@ def merge_data(
         target_data = squash_placeholders(target_data)
 
         ids_data = [
-            handle.get_variables(ids_name, empty_var_ok=True)  # type: ignore
+            handle.get_variables(variables, empty_var_ok=True)  # type: ignore
             for handle in handles
         ]
 

--- a/src/duqtools/ids/_merge.py
+++ b/src/duqtools/ids/_merge.py
@@ -10,7 +10,7 @@ from ._handle import ImasHandle
 from ._rebase import rebase_all_coords, squash_placeholders
 
 
-@add_to_op_queue('Merge', '{target}')
+@add_to_op_queue('Merging to', '{target}')
 def merge_data(
     handles: Sequence[ImasHandle],
     target: ImasHandle,
@@ -74,7 +74,7 @@ def merge_data(
 
         # Now we have to get the stddeviations
         mean_data = ids_data.mean(dim='handle')
-        std_data = ids_data.std(dim='handle')
+        std_data = ids_data.std(dim='handle', skipna=True)
 
         # Then, write it back to target
         for name in ids_data.data_vars.keys():

--- a/src/duqtools/ids/_merge.py
+++ b/src/duqtools/ids/_merge.py
@@ -17,11 +17,6 @@ def raise_if_ids_inconsistent(*variables: IDSVariableModel):
 
 
 @add_to_op_queue('Merge', '{target}')
-def queue_merge_data(*args, **kwargs):
-    """Queued version of `merge_data()`."""
-    return merge_data(*args, **kwargs)
-
-
 def merge_data(
     source_data: Dict[str, ImasHandle],
     target: ImasHandle,

--- a/src/duqtools/ids/_rebase.py
+++ b/src/duqtools/ids/_rebase.py
@@ -214,9 +214,6 @@ def rebase_all_coords(
 ) -> Tuple[xr.Dataset, ...]:
     """Rebase all coords, by applying rebase operations.
 
-    Note, does not rebase a dimension with a single value (thats why we use
-    rebase_on_time as a wrapper for rebase_on_grid).
-
     Parameters
     ----------
     datasets : Sequence[xr.Dataset]

--- a/src/duqtools/ids/_rebase.py
+++ b/src/duqtools/ids/_rebase.py
@@ -206,3 +206,31 @@ def standardize_grid_and_time(
         for ds in datasets)
 
     return datasets
+
+
+def rebase_all_coords(
+    datasets: Sequence[xr.Dataset],
+    reference_dataset: xr.Dataset,
+) -> Tuple[xr.Dataset, ...]:
+    """Rebase all coords, by applying rebase operations.
+
+    Note, does not rebase a dimension with a single value (thats why we use
+    rebase_on_time as a wrapper for rebase_on_grid).
+
+    Parameters
+    ----------
+    datasets : Sequence[xr.Dataset]
+        datasets
+    reference_dataset : int
+        reference_dataset
+
+    Returns
+    -------
+    Tuple[xr.Dataset, ...]
+    """
+
+    for name, dim in reference_dataset.coords.items():
+        rebased_datasets = tuple(
+            rebase_on_time(ds, time_dim=name, new_coords=dim.data)
+            for ds in datasets)
+    return rebased_datasets

--- a/src/duqtools/ids/_rebase.py
+++ b/src/duqtools/ids/_rebase.py
@@ -229,8 +229,8 @@ def rebase_all_coords(
     Tuple[xr.Dataset, ...]
     """
 
-    for name, dim in reference_dataset.coords.items():
-        rebased_datasets = tuple(
-            rebase_on_time(ds, time_dim=name, new_coords=dim.data)
-            for ds in datasets)
-    return rebased_datasets
+    interp_dict = {name: dim for name, dim in reference_dataset.coords.items()}
+
+    return tuple(
+        ds.interp(coords=interp_dict, kwargs={'fill_value': 'extrapolate'})
+        for ds in datasets)

--- a/src/duqtools/merge.py
+++ b/src/duqtools/merge.py
@@ -30,7 +30,7 @@ def merge(*, merge_all: bool, **kwargs):
 
     if merge_all:
         variables = [
-            var for var in var_lookup.values() if var.type == 'IDS-variables'
+            var for var in var_lookup.values() if var.type == 'IDS-variable'
         ]
         op_queue.add(action=lambda: None,
                      description='Merging all known variables')

--- a/src/duqtools/merge.py
+++ b/src/duqtools/merge.py
@@ -5,13 +5,13 @@ import logging
 from .config import cfg, var_lookup
 from .ids import ImasHandle, merge_data
 from .operations import op_queue
-from .utils import partition, read_imas_handles_from_file
+from .utils import read_imas_handles_from_file
 
 logger = logging.getLogger(__name__)
 info, debug = logger.info, logger.debug
 
 
-def merge(**kwargs):
+def merge(*, merge_all: bool, **kwargs):
     """Merge as many data as possible."""
     template = ImasHandle.parse_obj(cfg.merge.template)
     target = ImasHandle.parse_obj(cfg.merge.output)
@@ -29,9 +29,9 @@ def merge(**kwargs):
     template.copy_data_to(target)
 
     if merge_all:
-        _, variables = partition(lambda var: var.type == 'IDS-variable',
-                                 var_lookup.values())
-        variables = list(variables)
+        variables = [
+            var for var in var_lookup.values() if var.type == 'IDS-variables'
+        ]
         op_queue.add(action=lambda: None,
                      description='Merging all known variables')
     else:

--- a/src/duqtools/merge.py
+++ b/src/duqtools/merge.py
@@ -2,58 +2,31 @@ from __future__ import annotations
 
 import logging
 
-from duqtools.config import var_lookup
-
-from .config import cfg
-from .ids import ImasHandle, merge_data, rebase_all_coords, squash_placeholders
-from .utils import groupby, partition, read_imas_handles_from_file
+from .config import cfg, var_lookup
+from .ids import ImasHandle, merge_data
+from .utils import partition, read_imas_handles_from_file
 
 logger = logging.getLogger(__name__)
 info, debug = logger.info, logger.debug
 
 
 def merge(**kwargs):
-    """Merge data."""
+    """Merge as many data as possible."""
     template = ImasHandle.parse_obj(cfg.merge.template)
     target = ImasHandle.parse_obj(cfg.merge.output)
 
-    handles = read_imas_handles_from_file(cfg.merge.data)
+    handles = read_imas_handles_from_file(cfg.merge.data).values()
 
     debug('Merge input: %s', template)
     debug('Merge output: %s', target)
 
     template.copy_data_to(target)
 
-    for step in cfg.merge.plan:
-        merge_data(source_data=handles,
-                   target=target,
-                   time_var=step.time_variable,
-                   grid_var=step.grid_variable,
-                   data_vars=step.data_variables)
-
-
-def merge_all(**kwargs):
-    """Merge as many data as possible."""
-
-    handles = read_imas_handles_from_file(cfg.merge.data)
-
-    # Get all known variables per ids
-    _, ids_variables = partition(lambda var: var.type == 'IDS-variable',
+    if kwargs['all']:
+        _, variables = partition(lambda var: var.type == 'IDS-variable',
                                  var_lookup.values())
-    grouped_ids_vars = groupby(ids_variables, keyfunc=lambda var: var.ids)
+        variables = list(variables)
+    else:
+        variables = [var_lookup[name] for name in cfg.merge.variables]
 
-    # Get all data, and rebase it
-    for ids_name, variables in grouped_ids_vars.items():
-        idss = [handle.get(ids_name) for handle in handles.values()]
-
-        ids_data = [
-            ids.to_xarray(
-                variables=variables,
-                empty_var_ok=True,
-            ) for ids in idss
-        ]
-        ids_data = [squash_placeholders(data) for data in ids_data]
-
-        ids_data = rebase_all_coords(ids_data, ids_data[0])
-
-        # Now we have to squash it and write it to the target IDS
+    merge_data(handles, target, variables)

--- a/src/duqtools/merge.py
+++ b/src/duqtools/merge.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import logging
 
+from duqtools.config import var_lookup
+
 from .config import cfg
-from .ids import ImasHandle, queue_merge_data
-from .utils import read_imas_handles_from_file
+from .ids import ImasHandle, merge_data, rebase_all_coords, squash_placeholders
+from .utils import groupby, partition, read_imas_handles_from_file
 
 logger = logging.getLogger(__name__)
 info, debug = logger.info, logger.debug
@@ -17,14 +19,41 @@ def merge(**kwargs):
 
     handles = read_imas_handles_from_file(cfg.merge.data)
 
+    debug('Merge input: %s', template)
+    debug('Merge output: %s', target)
+
+    template.copy_data_to(target)
+
     for step in cfg.merge.plan:
-        debug('Merge input: %s', template)
-        debug('Merge output: %s', target)
+        merge_data(source_data=handles,
+                   target=target,
+                   time_var=step.time_variable,
+                   grid_var=step.grid_variable,
+                   data_vars=step.data_variables)
 
-        template.copy_data_to(target)
 
-        queue_merge_data(source_data=handles,
-                         target=target,
-                         time_var=step.time_variable,
-                         grid_var=step.grid_variable,
-                         data_vars=step.data_variables)
+def merge_all(**kwargs):
+    """Merge as many data as possible."""
+
+    handles = read_imas_handles_from_file(cfg.merge.data)
+
+    # Get all known variables per ids
+    _, ids_variables = partition(lambda var: var.type == 'IDS-variable',
+                                 var_lookup.values())
+    grouped_ids_vars = groupby(ids_variables, keyfunc=lambda var: var.ids)
+
+    # Get all data, and rebase it
+    for ids_name, variables in grouped_ids_vars.items():
+        idss = [handle.get(ids_name) for handle in handles.values()]
+
+        ids_data = [
+            ids.to_xarray(
+                variables=variables,
+                empty_var_ok=True,
+            ) for ids in idss
+        ]
+        ids_data = [squash_placeholders(data) for data in ids_data]
+
+        ids_data = rebase_all_coords(ids_data, ids_data[0])
+
+        # Now we have to squash it and write it to the target IDS

--- a/src/duqtools/merge.py
+++ b/src/duqtools/merge.py
@@ -28,7 +28,7 @@ def merge(**kwargs):
 
     template.copy_data_to(target)
 
-    if kwargs['all']:
+    if merge_all:
         _, variables = partition(lambda var: var.type == 'IDS-variable',
                                  var_lookup.values())
         variables = list(variables)

--- a/src/duqtools/merge.py
+++ b/src/duqtools/merge.py
@@ -26,9 +26,6 @@ def merge(**kwargs):
                  description='Merging template',
                  extra_description=f'{template}')
 
-    debug('Merge input: %s', template)
-    debug('Merge output: %s', target)
-
     template.copy_data_to(target)
 
     if kwargs['all']:

--- a/src/duqtools/merge.py
+++ b/src/duqtools/merge.py
@@ -4,6 +4,7 @@ import logging
 
 from .config import cfg, var_lookup
 from .ids import ImasHandle, merge_data
+from .operations import op_queue
 from .utils import partition, read_imas_handles_from_file
 
 logger = logging.getLogger(__name__)
@@ -17,6 +18,14 @@ def merge(**kwargs):
 
     handles = read_imas_handles_from_file(cfg.merge.data).values()
 
+    for handle in handles:
+        op_queue.add(action=lambda: None,
+                     description='Merging source',
+                     extra_description=f'{handle}')
+    op_queue.add(action=lambda: None,
+                 description='Merging template',
+                 extra_description=f'{template}')
+
     debug('Merge input: %s', template)
     debug('Merge output: %s', target)
 
@@ -26,7 +35,13 @@ def merge(**kwargs):
         _, variables = partition(lambda var: var.type == 'IDS-variable',
                                  var_lookup.values())
         variables = list(variables)
+        op_queue.add(action=lambda: None,
+                     description='Merging all known variables')
     else:
         variables = [var_lookup[name] for name in cfg.merge.variables]
+        for variable in variables:
+            op_queue.add(action=lambda: None,
+                         description='Merging variable',
+                         extra_description=f'{variable.name}')
 
     merge_data(handles, target, variables)

--- a/src/duqtools/schema/cli.py
+++ b/src/duqtools/schema/cli.py
@@ -152,48 +152,6 @@ class StatusConfigModel(BaseModel):
             """))
 
 
-class MergeStep(BaseModel):
-    """These parameters describe which paths should be merged.
-
-    Three sets of variables need to be defined:
-    - time_variable: this points to the data for the time coordinate
-    - grid_variable: this points to the data for the grid variable
-    - data_variables: these point to the data to be merged
-
-    Note that all variables must be from the same IDS.
-
-    The grid and data variables must share a common dimension. The grid variable
-    will be used to rebase all data variables to a common grid.
-
-    The time variable will be used to rebase the grid variable and the data variables
-    to a common time coordinate. To denote the time index, use `/*/` in both
-    the grid and data variables.
-
-    Rebasing involves interpolation.
-
-    Note that multiple merge steps can be specified, for example for different
-    IDS.
-    """
-    data_variables: List[str] = Field(description=f("""
-            This is a list of data variables to be merged. This means
-            that the mean and error for these data over all runs are calculated
-            and written back to the ouput data location.
-            The paths should contain `/*/` for the time component or other dimensions.
-            """))
-    grid_variable: str = Field(description=f("""
-            This variable points to the data for the grid coordinate. It must share a common
-            placeholder dimension with the data variables.
-            It will be used to rebase all data variables to same (radial) grid before merging
-            using interpolation.
-            The path should contain '/*/' to denote the time component or other dimension.
-            """))
-    time_variable: str = Field(description=f("""
-            This variable determines the time coordinate to merge on. This ensures
-            that the data from all runs are on the same time coordinates before
-            merging.
-            """))
-
-
 class MergeConfigModel(BaseModel):
     """The options of the `merge` subcommand are stored under the `merge` key
     in the config.
@@ -214,7 +172,11 @@ class MergeConfigModel(BaseModel):
             """))
     output: ImasBaseModel = Field(
         description='Merged data will be written to this IMAS DB entry.')
-    plan: List[MergeStep] = Field(description='List of merging operations.')
+    variables: List[str] = Field(description=f("""
+            This is a list of variables to be merged. This means
+            that the mean and error for these data over all runs are calculated
+            and written back to the ouput data location.
+            """))
 
 
 class ConfigModel(BaseModel):


### PR DESCRIPTION
This PR introduces a `merge -all` command, and simplifies the existing `merge` command

- the `cfg.merge.steps` config variable is removed in favor of `cfg.merge.variables`. duqtools can now figure out all the dimensions and stuff if necessary

- [ ] Optional, we still have to find a way to check the quality of the standard distribution, but we could add that later to duqtools if requested