### PR TITLE
Enable multiple IDS in dashboard and simplify variable selection

### DIFF
--- a/src/duqtools/config/_variables.py
+++ b/src/duqtools/config/_variables.py
@@ -28,6 +28,7 @@ VAR_FILENAME_GLOB = 'variables*.yaml'
 
 
 class VarLookup(UserDict):
+    _prefix = '$'
     """Variable lookup table.
 
     Subclasses `UserDict` to embed some commonly used operations, like
@@ -36,9 +37,14 @@ class VarLookup(UserDict):
     _ids_variable_key = 'IDS-variable'
 
     def __getitem__(self, key: str) -> IDSVariableModel:
-        if key.startswith('$'):
-            return self.data[key[1:]]
-        return self.data[key]
+        return self.data[self.normalize(key)]
+
+    def normalize(self, *keys: str) -> Union[str, Tuple[str, ...]]:
+        """Normalize variable names (remove `$`)."""
+        keys = tuple(key.lstrip(self._prefix) for key in keys)
+        if len(keys) == 1:
+            return keys[0]
+        return keys
 
     def filter_type(self, type: str, *, invert: bool = False) -> VarLookup:
         """Filter all entries of given type."""

--- a/src/duqtools/data/dash/_shared.py
+++ b/src/duqtools/data/dash/_shared.py
@@ -37,33 +37,36 @@ def get_variables(*, ids: str, x_key: str, y_keys: Sequence[str]):
 
 
 @st.experimental_memo
-def _get_dataset(handles, *, ids, time_var, grid_var, data_vars):
-    datasets = []
+def _get_dataset(handles, variable):
+    data_var = variable['name']
+    time_var = variable['dims'][0]
+    grid_var = variable['dims'][1]
 
-    variables = tuple((time_var, grid_var, *data_vars))
+    datasets = []
 
     for name, handle in handles.items():
         handle = ImasHandle(**handle)
-        ds = handle.get_variables(variables=variables)
+        ds = handle.get_variables(variables=(time_var, grid_var, data_var))
         datasets.append(ds)
+
+    grid_var_norm = var_lookup.normalize(grid_var)
+    time_var_norm = var_lookup.normalize(time_var)
 
     datasets = standardize_grid_and_time(
         datasets,
-        grid_var=grid_var,
-        time_var=time_var,
+        grid_var=grid_var_norm,
+        time_var=time_var_norm,
     )
 
     dataset = xr.concat(datasets, 'run')
     dataset['run'] = list(handles.keys())
 
-    return dataset
+    return dataset, time_var_norm, grid_var_norm, data_var
 
 
-def get_dataset(handles, *, ids, time_var, grid_var, data_vars):
+def get_dataset(handles, variable):
     """Convert to hashable types before calling `_get_dataset`."""
     handles = {name: handle.dict() for name, handle in handles.items()}
-    return _get_dataset(handles,
-                        ids=ids,
-                        time_var=time_var,
-                        grid_var=grid_var,
-                        data_vars=data_vars)
+    variable = variable.dict()
+
+    return _get_dataset(handles, variable)

--- a/src/duqtools/data/dash/_shared.py
+++ b/src/duqtools/data/dash/_shared.py
@@ -19,7 +19,7 @@ PREFIX0 = 'profiles_1d/0'
 
 @st.experimental_memo
 def get_ids_options():
-    return tuple(var_lookup.filter_type('IDS-variables').keys())
+    return tuple(var_lookup.filter_type('IDS-variable').keys())
 
 
 @st.experimental_memo

--- a/src/duqtools/data/dash/dash.py
+++ b/src/duqtools/data/dash/dash.py
@@ -5,6 +5,7 @@ import streamlit as st
 from _shared import default_workdir, get_dataset
 
 from duqtools._plot_utils import alt_errorband_chart, alt_line_chart
+from duqtools.config import var_lookup
 from duqtools.utils import read_imas_handles_from_file
 
 st.title('Plot IDS')
@@ -28,13 +29,11 @@ with st.expander('Click to show runs'):
     st.table(df)
 
 with st.sidebar:
-    from duqtools.config import var_lookup
-
     ids_variables = var_lookup.filter_type('IDS-variable')
 
     var_names = st.multiselect('Select variable',
                                tuple(ids_variables),
-                               default='t_i_ave')
+                               default=None)
 
     st.header('Plotting options')
 


### PR DESCRIPTION
This PR revises the dashboard so that multiple IDS can be plotted. It also automatically retrieves the grid/time variables and passes them to the plotting functions. This simplifies the data input selection.

Closes #418
Addresses #439 