### PR TITLE
Update jetto tools to 1.8.8

### DIFF
--- a/.github/workflows/test_imas.yaml
+++ b/.github/workflows/test_imas.yaml
@@ -52,10 +52,6 @@ jobs:
           pwd
           ls -alh
 
-      - name: Install tkinter # remove if jetto-tools fixed
-        run: |
-          yum install -y python39-tkinter
-
       - uses: actions/cache@v3
         with:
           path: .imasenv

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,7 +58,7 @@ install_requires =
     tqdm
     typing-extensions;python_version<'3.9'
     xarray
-    jetto-tools >= 1.8.6
+    jetto-tools >= 1.8.8
 
 [options.extras_require]
 develop =

--- a/src/duqtools/__init__.py
+++ b/src/duqtools/__init__.py
@@ -1,7 +1,7 @@
 # https://setuptools.pypa.io/en/latest/pkg_resources.html#workingset-objects
 def fix_dependencies():
     import __main__
-    __main__.__requires__ = ['jetto_tools>=1.8.6']
+    __main__.__requires__ = ['jetto_tools>=1.8.8']
     import pkg_resources  # noqa
 
 


### PR DESCRIPTION
This PR updates the jetto python tools to 1.8.8 which works in environments without tkinter available.