### PR TITLE
Work-around streamlit version for docker image

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install -e .[develop,dash]
+          python -m pip install -e .[develop]
 
       - name: Test with pytest
         run: coverage run -p -m pytest

--- a/.github/workflows/test_imas.yaml
+++ b/.github/workflows/test_imas.yaml
@@ -63,10 +63,10 @@ jobs:
             python3 -m venv .imasenv
             . .imasenv/bin/activate
             python -m pip install wheel
-            python -m pip install -e .[develop,dash]
+            python -m pip install -e .[develop]
           else
             . .imasenv/bin/activate
-            python -m pip install -e .[develop,dash]
+            python -m pip install -e .[develop]
           fi
 
           echo "VIRTUAL_ENV=${VIRTUAL_ENV}" >> $GITHUB_ENV

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,6 +56,11 @@ install_requires =
     tqdm
     xarray
     jetto-tools >= 1.8.8
+    # Work-around for docker image which runs python 3.9.7
+    # https://github.com/gitpython-developers/GitPython/issues/1332
+    streamlit == 1.11;python_full_version=='3.9.7'
+    streamlit >= 1.12;python_full_version!='3.9.7'
+    
 
 [options.extras_require]
 develop =
@@ -87,8 +92,7 @@ publishing =
     build
 imas =
     imas
-dash =
-    streamlit >= 1.12
+
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
This PR works around a bug with streamlit for Python 3.9.7 (the version on the docker image). See [here](https://stackoverflow.com/questions/73530174/streamlit-protocols-cannot-be-instantiated) for more info. This PR also installs streamlit by default.