### PR TITLE
Update .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,9 +7,9 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
-    python: "3.7"
+    python: "3.9"
 
 # Build documentation in the docs/ directory with Sphinx
 mkdocs:


### PR DESCRIPTION
This PR fixes the readthedocs build which now fails, because it still runs on Python 3.7