### PR TITLE
Support running tests in docker container

### DIFF
--- a/.github/workflows/test_imas.yaml
+++ b/.github/workflows/test_imas.yaml
@@ -45,6 +45,8 @@ jobs:
           mkdir -p ${HOME}/public/
           ln -s `pwd`/containerized_runs/imasdb /opt/imas/shared/
           ln -s `pwd`/containerized_runs/imasdb ${HOME}/public/imasdb
+          echo `pwd`/containerized_runs/imasdb
+          echo ${HOME}/public/imasdb
 
       - name: Python and Environment info
         run: |

--- a/.github/workflows/test_imas.yaml
+++ b/.github/workflows/test_imas.yaml
@@ -41,11 +41,12 @@ jobs:
 
       - name: Put the IMAS db in the right location
         run: |
-          mkdir /opt/imas/shared
-          ln -s `pwd`/containerized_runs/imasdb /opt/imas/shared/
+          mkdir ${HOME}/public/ -p
+          ln -s `pwd`/containerized_runs/imasdb ${HOME}/public/imasdb
 
       - name: Python and Environment info
         run: |
+          whoami
           which python
           python --version
           pwd

--- a/.github/workflows/test_imas.yaml
+++ b/.github/workflows/test_imas.yaml
@@ -42,7 +42,9 @@ jobs:
       - name: Put the IMAS db in the right location
         run: |
           mkdir /opt/imas/shared
+          mkdir -p ${HOME}/public/
           ln -s `pwd`/containerized_runs/imasdb /opt/imas/shared/
+          ln -s `pwd`/containerized_runs/imasdb ${HOME}/public/imasdb
 
       - name: Python and Environment info
         run: |

--- a/.github/workflows/test_imas.yaml
+++ b/.github/workflows/test_imas.yaml
@@ -61,6 +61,13 @@ jobs:
           path: .imasenv
           key: ${{ hashFiles('setup.cfg') }}
 
+      - name: Test paths
+        shell: python
+        run: |
+          from duqtools.api import ImasHandle
+          print(ImasHandle.from_string('root/test/11111/6666').path())
+          print(ImasHandle.from_string('test/11111/4444').path())
+
       - name: Create venv and setup duqtools
         run: |
           if ! test -d ".imasenv"; then

--- a/.github/workflows/test_imas.yaml
+++ b/.github/workflows/test_imas.yaml
@@ -41,8 +41,8 @@ jobs:
 
       - name: Put the IMAS db in the right location
         run: |
-          mkdir ${HOME}/public/ -p
-          ln -s `pwd`/containerized_runs/imasdb ${HOME}/public/imasdb
+          mkdir /opt/imas/shared
+          ln -s `pwd`/containerized_runs/imasdb /opt/imas/shared/
 
       - name: Python and Environment info
         run: |

--- a/.github/workflows/test_imas.yaml
+++ b/.github/workflows/test_imas.yaml
@@ -61,13 +61,6 @@ jobs:
           path: .imasenv
           key: ${{ hashFiles('setup.cfg') }}
 
-      - name: Test paths
-        shell: python
-        run: |
-          from duqtools.api import ImasHandle
-          print(ImasHandle.from_string('root/test/11111/6666').path())
-          print(ImasHandle.from_string('test/11111/4444').path())
-
       - name: Create venv and setup duqtools
         run: |
           if ! test -d ".imasenv"; then
@@ -87,6 +80,13 @@ jobs:
         run: |
           . /docker-entrypoint.sh
           python -m imas
+
+      - name: Test paths
+        shell: python
+        run: |
+          from duqtools.api import ImasHandle
+          print(ImasHandle.from_string('root/test/11111/6666').path())
+          print(ImasHandle.from_string('test/11111/4444').path())
 
       - name: Test with pytest
         run: |

--- a/src/duqtools/cli.py
+++ b/src/duqtools/cli.py
@@ -385,7 +385,7 @@ def cli_yolo(ctx, **kwargs):
 
 
 @cli.command('dash', cls=GroupCmd)
-@common_options(*all_options)
+@common_options(*logging_options, quiet_option, dry_run_option, yes_option)
 def cli_dash(**kwargs):
     """Open dashboard for evaluating IDS data."""
     from .dash import dash

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -115,7 +115,7 @@ def test_example_plot(cmdline_workdir):
     if imas_mocked:
         pytest.xfail('Imas needed for plotting Imas data')
 
-    cmd = ('duqtools plot -h root/test/11111/6666 -v t_i_ave').split()
+    cmd = ('duqtools plot -h public/test/11111/6666 -v t_i_ave').split()
 
     with work_directory(cmdline_workdir):
         result = sp.run(cmd)

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -115,7 +115,7 @@ def test_example_plot(cmdline_workdir):
     if imas_mocked:
         pytest.xfail('Imas needed for plotting Imas data')
 
-    cmd = ('duqtools plot -h root/test/11111/2222 -v t_i_ave').split()
+    cmd = ('duqtools plot -h root/test/11111/6666 -v t_i_ave').split()
 
     with work_directory(cmdline_workdir):
         result = sp.run(cmd)

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -115,7 +115,7 @@ def test_example_plot(cmdline_workdir):
     if imas_mocked:
         pytest.xfail('Imas needed for plotting Imas data')
 
-    cmd = ('duqtools plot -h public/aug/36982/167 -v t_i_ave').split()
+    cmd = ('duqtools plot -h root/test/11111/2222 -v t_i_ave').split()
 
     with work_directory(cmdline_workdir):
         result = sp.run(cmd)

--- a/tests/test_data/config_jetto.yaml
+++ b/tests/test_data/config_jetto.yaml
@@ -19,11 +19,12 @@ create:
     n_samples: 3
   data:
     user: public
-    imasdb: aug
+    imasdb: test
     run_in_start_at: 7000
     run_out_start_at: 8000
   template: ./template_model
   template_data:
+    user: public
     db: test
     shot: 11111
     run: 6666

--- a/tests/test_data/config_jetto.yaml
+++ b/tests/test_data/config_jetto.yaml
@@ -19,12 +19,12 @@ create:
     n_samples: 3
   data:
     user: public
-    imasdb: test
+    imasdb: aug
     run_in_start_at: 7000
     run_out_start_at: 8000
   template: ./template_model
   template_data:
-    user: public
+    user: root
     db: test
     shot: 11111
     run: 6666

--- a/tests/test_data/config_jetto.yaml
+++ b/tests/test_data/config_jetto.yaml
@@ -23,6 +23,11 @@ create:
     run_in_start_at: 7000
     run_out_start_at: 8000
   template: ./template_model
+  template_data:
+    user: root
+    db: test
+    shot: 11111
+    run: 2222
 extra_variables:
   - name: my_extra_var
     ids: core_profiles

--- a/tests/test_data/config_jetto.yaml
+++ b/tests/test_data/config_jetto.yaml
@@ -19,12 +19,12 @@ create:
     n_samples: 3
   data:
     user: public
-    imasdb: aug
+    imasdb: test
     run_in_start_at: 7000
     run_out_start_at: 8000
   template: ./template_model
   template_data:
-    user: root
+    user: public
     db: test
     shot: 11111
     run: 6666

--- a/tests/test_data/config_jetto.yaml
+++ b/tests/test_data/config_jetto.yaml
@@ -24,7 +24,6 @@ create:
     run_out_start_at: 8000
   template: ./template_model
   template_data:
-    user: root
     db: test
     shot: 11111
     run: 6666

--- a/tests/test_data/config_jetto.yaml
+++ b/tests/test_data/config_jetto.yaml
@@ -27,7 +27,7 @@ create:
     user: root
     db: test
     shot: 11111
-    run: 2222
+    run: 6666
 extra_variables:
   - name: my_extra_var
     ids: core_profiles


### PR DESCRIPTION
Support testing in a docker container using https://github.com/duqtools/containerized_runs.

- Tests should exclusively use the handle: `root/test/11111/{5555,6666,7777}` (or something else that we add to the test db in `containerized_runs`.
- I left `root/test/11111/2222` in for now so we can create new datasets (if needed)

Closes #469

Depends on https://github.com/duqtools/containerized_runs/pull/5

Follow-up:

- Go through all the tests to see how they should be updated for new data
- Look into tests for data merging
- Add data with more than 1 timestep