### PR TITLE
Support adding an index at the end of a key in `IDSMapping.__getitem__`

### DIFF
--- a/tests/ids/test_mapping.py
+++ b/tests/ids/test_mapping.py
@@ -42,6 +42,9 @@ def test_mapping():
     assert_equal(s['data/2/x'], np.array([8, 9]))
     assert_equal(s['data/2/y'], np.array([10, 11]))
 
+    assert_equal(s['data/0/x/0'], 0)
+    assert_equal(s['data/0/x/1'], 1)
+
     assert 'data/0/z' not in s._keys
 
 


### PR DESCRIPTION
The goal if this PR is to support grabbing a key with an index at the end. This makes it easier to define paths to numbers in an array in a config file.

### Example:

```python
>>> from duqtools.api import ImasHandle
>>> h = ImasHandle.from_str('test/11111/7000')
>>> cp = h.get('core_profiles')
>>> cp['profiles_1d/0/zeff']
array([2.016, 2.016, ..., 2.016, 2.016])
>>> cp['profiles_1d/0/zeff/0']  # <-- new
2.016
```
