### PR TITLE
Implement lookup table to define IDS-to-jetto conversion

### DIFF
--- a/docs/templates/template_variables.md
+++ b/docs/templates/template_variables.md
@@ -17,6 +17,13 @@ In the list below, you will find variables prefixed `$`. This means that these v
 
 The default duqtools variables are listed below.
 
+{% for name in ids_vars %}
+- [IDS: {{ name }}](#ids-{{ name }})
+{% endfor %}
+{% for name in other_vars %}
+- [{{ name }}s](#{{ name | lower }}s)
+{% endfor %}
+
 {% for name, var_group in ids_vars.items() %}
 ### IDS: {{ name }}
 

--- a/src/duqtools/data/variables_ids2jetto.yaml
+++ b/src/duqtools/data/variables_ids2jetto.yaml
@@ -15,8 +15,10 @@
     - ids: equilibrium
       path: time_slice/0/global_quantities/magnetic_axis/b_field_tor/0
   accept_if:
-    - [ne, 0]
-    - [lt, 1e40]
+    - operator: eq
+      args: [0]
+    - operator: lt
+      args: [1e40]
   default: null  # raise if None
 
 - name: ids-major_radius
@@ -27,6 +29,8 @@
     - ids: equilibrium
       path: time_slice/0/global_quantities/magnetic_axis/r
   accept_if:
-    - [ne, 0]
-    - [lt, 1e40]
+    - operator: ne
+      args: [0]
+    - operator: lt
+      args: [1e40]
   default: null  # raise if None

--- a/src/duqtools/data/variables_ids2jetto.yaml
+++ b/src/duqtools/data/variables_ids2jetto.yaml
@@ -1,0 +1,32 @@
+### Convert from IDs to jetto/other variables
+
+- name: ids-t_start
+  type: IDS2jetto-variable
+  paths:
+    - ids: equilibrium
+      path: time/0
+  default: null  # raise if None
+
+- name: ids-b_field
+  type: IDS2jetto-variable
+  paths:
+    - ids: equilibrium
+      path: vacuum_toroidal_field/b0/0
+    - ids: equilibrium
+      path: time_slice/0/global_quantities/magnetic_axis/b_field_tor/0
+  accept_if:
+    - [ne, 0]
+    - [lt, 1e40]
+  default: null  # raise if None
+
+- name: ids-major_radius
+  type: IDS2jetto-variable
+  paths:
+    - ids: equilibrium
+      path: vacuum_toroidal_field/r0
+    - ids: equilibrium
+      path: time_slice/0/global_quantities/magnetic_axis/r
+  accept_if:
+    - [ne, 0]
+    - [lt, 1e40]
+  default: null  # raise if None

--- a/src/duqtools/data/variables_ids2jetto.yaml
+++ b/src/duqtools/data/variables_ids2jetto.yaml
@@ -5,6 +5,8 @@
   paths:
     - ids: equilibrium
       path: time/0
+    - ids: core_profiles
+      path: time/0
   default: null  # raise if None
 
 - name: ids-b_field

--- a/src/duqtools/large_scale_validation/setup.py
+++ b/src/duqtools/large_scale_validation/setup.py
@@ -114,7 +114,7 @@ class Variables:
             spec = self.lookup[f'ids-{key}']
         except KeyError as exc:
             msg = f'Cannot find {key!r} in your variable listing (i.e. `variables.yaml`).'
-            raise KeyError(msg) from exc
+            raise AttributeError(msg) from exc
 
         value = spec.default
 
@@ -130,7 +130,7 @@ class Variables:
                 break
 
         if value is None:
-            raise ValueError(
+            raise AttributeError(
                 f'No value matches specifications given by: {spec}')
 
         return value

--- a/src/duqtools/large_scale_validation/setup.py
+++ b/src/duqtools/large_scale_validation/setup.py
@@ -104,11 +104,11 @@ class Variables:
 
     @property
     def t_start(self):
-        model = self.lookup['ids-t_start']
+        spec = self.lookup['ids-t_start']
 
-        value = model.default
+        value = spec.default
 
-        for item in model.paths:
+        for item in spec.paths:
             # from IPython import embed; embed()
 
             mapping = self.handle.get(item.ids)
@@ -117,7 +117,7 @@ class Variables:
             except KeyError:
                 continue
 
-            for cond in model.accept_if:
+            for cond in spec.accept_if:
                 test = getattr(operator, cond.operator)
                 if not test(trial, *cond.args):
                     break
@@ -126,7 +126,8 @@ class Variables:
                 break
 
         if not value:
-            raise ValueError(f'Cannot look up value for: {model}')
+            raise ValueError(
+                f'No value matches specifications given by: {spec}')
 
         return value
 

--- a/src/duqtools/large_scale_validation/setup.py
+++ b/src/duqtools/large_scale_validation/setup.py
@@ -148,8 +148,7 @@ def setup(*, template_file, input_file, force, **kwargs):
     template = get_template(template_file)
 
     if _get_key(template_file, key='system') == 'jetto-v210921':
-        extra_params = ExtrasV210921(template_file)
-        add_system_attrs = extra_params.add_system_attrs
+        add_system_attrs = ExtrasV210921(template_file).add_system_attrs
     else:
         add_system_attrs = no_op  # default to no-op
 

--- a/src/duqtools/large_scale_validation/setup.py
+++ b/src/duqtools/large_scale_validation/setup.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import operator
 from collections import defaultdict
 from pathlib import Path
 from types import SimpleNamespace
@@ -126,11 +125,7 @@ class Variables:
             except KeyError:
                 continue
 
-            for cond in spec.accept_if:
-                test = getattr(operator, cond.operator)
-                if not test(trial, *cond.args):
-                    break
-            else:
+            if all(condition(trial) for condition in spec.accept_if):
                 value = trial
                 break
 

--- a/src/duqtools/large_scale_validation/setup.py
+++ b/src/duqtools/large_scale_validation/setup.py
@@ -97,20 +97,18 @@ class Variables:
     lookup = var_lookup.filter_type('IDS2jetto-variable')
 
     def __init__(self, *, handle: ImasHandle):
-        # TODO
-        # - Some sort of caching for the root ids
-        # - Implement __getattr__ to avoid defining properties
         self.handle = handle
 
-    @property
-    def t_start(self):
-        spec = self.lookup['ids-t_start']
+    def __getattr__(self, key: str):
+        try:
+            spec = self.lookup[f'ids-{key}']
+        except KeyError as exc:
+            msg = f'Cannot find {key!r} in your variable listing (i.e. `variables.yaml`).'
+            raise KeyError(msg) from exc
 
         value = spec.default
 
         for item in spec.paths:
-            # from IPython import embed; embed()
-
             mapping = self.handle.get(item.ids)
             try:
                 trial = mapping[item.path]
@@ -130,14 +128,6 @@ class Variables:
                 f'No value matches specifications given by: {spec}')
 
         return value
-
-    @property
-    def major_radius(self):
-        return 0
-
-    @property
-    def b_field(self):
-        return 0
 
 
 def setup(*, template_file, input_file, force, **kwargs):

--- a/src/duqtools/schema/_variable.py
+++ b/src/duqtools/schema/_variable.py
@@ -93,7 +93,8 @@ class IDS2JettoVariableModel(BaseModel):
         Search these variables in the given order until a match with the conditions
         defined below is found.
     """))
-    accept_if: Optional[list[Condition]] = Field(description=f("""
+    accept_if: Optional[list[Condition]] = Field([],
+                                                 description=f("""
         Accept variable if it matches the given conditions. This can be used
         to filter undefined values (i.e. set to 0 or some very small or large number).
         """))

--- a/src/duqtools/schema/_variable.py
+++ b/src/duqtools/schema/_variable.py
@@ -103,7 +103,6 @@ class IDS2JettoVariableModel(BaseModel):
         Accept variable if it matches the given conditions. This can be used
         to filter undefined values (i.e. set to 0 or some very small or large number).
         """))
-    default: Optional[float] = Field([],
-                                     description=f("""
+    default: Optional[float] = Field(description=f("""
         Default value if no match is found. Set to None to raise an exeption instead."""
                                                    ))

--- a/src/duqtools/schema/_variable.py
+++ b/src/duqtools/schema/_variable.py
@@ -74,6 +74,11 @@ class Condition(BaseModel):
         'Name of a function in the `operator` module in the standard library.')
     args: list[Any] = Field('Arguments to pass to the operator.')
 
+    def __call__(self, value: Any):
+        import operator
+        test = getattr(operator, self.operator)
+        return test(value, *self.args)
+
 
 class IDS2JettoVariableModel(BaseModel):
     """Variable for describing the relation between IDS data and jetto

--- a/src/duqtools/schema/_variable.py
+++ b/src/duqtools/schema/_variable.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Any, Optional
 
 from pydantic import Field
 
@@ -23,7 +23,15 @@ class JettoVariableModel(BaseModel):
     """))
 
 
-class IDSVariableModel(BaseModel):
+class IDSPath(BaseModel):
+    ids: str = Field(description='Root IDS name.')
+    path: str = Field(description=f("""
+        Path to the data within the IDS.
+        The fields are separated by forward slashes (`\\`).
+    """))
+
+
+class IDSVariableModel(IDSPath):
     """Variable for describing data within a IMAS database.
 
     The variable can be given a name, which will be used in the rest of the config
@@ -48,9 +56,48 @@ class IDSVariableModel(BaseModel):
     ids: str = Field(description='Root IDS name.')
     path: str = Field(description=f("""
         Path to the data within the IDS.
-        The fields are separated by forward slashes (`\\`).
+        The fields are separated by forward slashes (`/`).
     """))
     dims: list[str] = Field(description=f("""
         Give the dimensions of the data,
         i.e. [x] for 1D, or [x, y] for 2D data.
     """))
+
+
+class Condition(BaseModel):
+    """Only accept value if this condition returns `True`.
+
+    Equivalent to: `operator(X, *args)`, where `X` is the value
+    retrieved from the IDS paths.
+    """
+    operator: str = Field(
+        'Name of a function in the `operator` module in the standard library.')
+    args: list[Any] = Field('Arguments to pass to the operator.')
+
+
+class IDS2JettoVariableModel(BaseModel):
+    """Variable for describing the relation between IDS data and jetto
+    variables.
+
+    The variable can be given a name, which can be used in the config
+    template to reference the variable. It will also be used as the
+    column labels or on plots.
+    """
+    name: str = Field(description=f("""
+        Name of the variable.
+        This will be used to reference this variable.
+    """))
+    type: str = Field('IDS2jetto-variable',
+                      description='discriminator for the variable type')
+    paths: list[IDSPath] = Field(description=f("""
+        Search these variables in the given order until a match with the conditions
+        defined below is found.
+    """))
+    accept_if: Optional[list[Condition]] = Field(description=f("""
+        Accept variable if it matches the given conditions. This can be used
+        to filter undefined values (i.e. set to 0 or some very small or large number).
+        """))
+    default: Optional[float] = Field([],
+                                     description=f("""
+        Default value if no match is found. Set to None to raise an exeption instead."""
+                                                   ))

--- a/src/duqtools/schema/variables.py
+++ b/src/duqtools/schema/variables.py
@@ -1,11 +1,12 @@
 from typing import Union
 
 from ._basemodel import BaseModel
-from ._variable import IDSVariableModel, JettoVariableModel
+from ._variable import IDS2JettoVariableModel, IDSVariableModel, JettoVariableModel
 
 
 class VariableConfigModel(BaseModel):
-    __root__: list[Union[JettoVariableModel, IDSVariableModel]]
+    __root__: list[Union[JettoVariableModel, IDSVariableModel,
+                         IDS2JettoVariableModel]]
 
     def __iter__(self):
         yield from self.__root__

--- a/tests/test_ids2jetto_variables.py
+++ b/tests/test_ids2jetto_variables.py
@@ -114,3 +114,16 @@ def test_conditionals(var):
     var.lookup = lookup
 
     assert var.t_start == 20
+
+
+def test_getattr(var):
+    lookup = {'ids-t_start': None}
+
+    var.lookup = lookup
+
+    with pytest.raises(KeyError, match='does_not_exist'):
+        var.does_not_exist
+
+    # ensure that default attribute lookup does not fail
+    var.moo = 123
+    assert var.moo == 123

--- a/tests/test_ids2jetto_variables.py
+++ b/tests/test_ids2jetto_variables.py
@@ -80,7 +80,7 @@ def test_raise(var):
 
     var.lookup = lookup
 
-    with pytest.raises(ValueError):
+    with pytest.raises(AttributeError):
         var.t_start
 
 
@@ -109,7 +109,7 @@ def test_getattr(var):
 
     var.lookup = lookup
 
-    with pytest.raises(KeyError, match='does_not_exist'):
+    with pytest.raises(AttributeError, match='does_not_exist'):
         var.does_not_exist
 
     # ensure that default attribute lookup does not fail

--- a/tests/test_ids2jetto_variables.py
+++ b/tests/test_ids2jetto_variables.py
@@ -1,0 +1,116 @@
+import numpy as np
+import pytest
+
+from duqtools.api import IDSMapping
+from duqtools.large_scale_validation.setup import Variables
+from duqtools.schema._variable import IDS2JettoVariableModel
+
+
+@pytest.fixture
+def var():
+    class t0:
+        time = np.array((10, 20, 30))
+
+    class t1:
+        time = np.array((10, 20, 30))
+
+    handle = {'t0': IDSMapping(t0), 't1': IDSMapping(t1)}
+
+    return Variables(handle=handle)
+
+
+def test_pick_first(var):
+    lookup = {
+        'ids-t_start':
+        IDS2JettoVariableModel.parse_raw("""
+    name: ids-t_start
+    type: IDS2jetto-variable
+    paths:
+      - ids: t0
+        path: time/0
+      - ids: t1
+        path: time/1
+    """)
+    }
+
+    var.lookup = lookup
+    assert var.t_start == 10
+
+
+def test_pick_second(var):
+    lookup = {
+        'ids-t_start':
+        IDS2JettoVariableModel.parse_raw("""
+    name: ids-t_start
+    type: IDS2jetto-variable
+    paths:
+      - ids: t0
+        path: does-not-exist/0
+      - ids: t1
+        path: time/1
+    """)
+    }
+
+    var.lookup = lookup
+    assert var.t_start == 20
+
+
+def test_default(var):
+    lookup = {
+        'ids-t_start':
+        IDS2JettoVariableModel.parse_raw("""
+    name: ids-t_start
+    type: IDS2jetto-variable
+    paths:
+      - ids: t0
+        path: does-not-exist/0
+    default: 1337
+    """)
+    }
+
+    var.lookup = lookup
+    assert var.t_start == 1337
+
+
+def test_raise(var):
+    lookup = {
+        'ids-t_start':
+        IDS2JettoVariableModel.parse_raw("""
+    name: ids-t_start
+    type: IDS2jetto-variable
+    paths:
+      - ids: t0
+        path: does-not-exist/0
+    default: null
+    """)
+    }
+
+    var.lookup = lookup
+
+    with pytest.raises(ValueError):
+        var.t_start
+
+
+def test_conditionals(var):
+    lookup = {
+        'ids-t_start':
+        IDS2JettoVariableModel.parse_raw("""
+    name: ids-t_start
+    type: IDS2jetto-variable
+    paths:
+      - ids: t0
+        path: time/0
+      - ids: t1
+        path: time/1
+    default: null
+    accept_if:
+      - operator: ne
+        args: [10]
+      - operator: gt
+        args: [0]
+    """)
+    }
+
+    var.lookup = lookup
+
+    assert var.t_start == 20

--- a/tests/test_ids2jetto_variables.py
+++ b/tests/test_ids2jetto_variables.py
@@ -12,7 +12,7 @@ def var():
         time = np.array((10, 20, 30))
 
     class t1:
-        time = np.array((10, 20, 30))
+        time = np.array((40, 50, 60))
 
     handle = {'t0': IDSMapping(t0), 't1': IDSMapping(t1)}
 
@@ -48,7 +48,7 @@ def test_pick_second(var):
     }
 
     var.lookup = lookup
-    assert var.t_start == 20
+    assert var.t_start == 50
 
 
 def test_default(var):
@@ -95,13 +95,13 @@ def test_conditionals(var):
       - {ids: t1, path: time/1}
     accept_if:
       - {operator: ne, args: [10]}
-      - {operator: gt, args: [0]}
+      - {operator: gt, args: [35]}
     """)
     }
 
     var.lookup = lookup
 
-    assert var.t_start == 20
+    assert var.t_start == 50
 
 
 def test_getattr(var):

--- a/tests/test_ids2jetto_variables.py
+++ b/tests/test_ids2jetto_variables.py
@@ -26,10 +26,8 @@ def test_pick_first(var):
     name: ids-t_start
     type: IDS2jetto-variable
     paths:
-      - ids: t0
-        path: time/0
-      - ids: t1
-        path: time/1
+      - {ids: t0, path: time/0}
+      - {ids: t1, path: time/1}
     """)
     }
 
@@ -44,10 +42,8 @@ def test_pick_second(var):
     name: ids-t_start
     type: IDS2jetto-variable
     paths:
-      - ids: t0
-        path: does-not-exist/0
-      - ids: t1
-        path: time/1
+      - {ids: t0, path: does-not-exist/0}
+      - {ids: t1, path: time/1}
     """)
     }
 
@@ -62,8 +58,7 @@ def test_default(var):
     name: ids-t_start
     type: IDS2jetto-variable
     paths:
-      - ids: t0
-        path: does-not-exist/0
+      - {ids: t0, path: does-not-exist/0}
     default: 1337
     """)
     }
@@ -79,9 +74,7 @@ def test_raise(var):
     name: ids-t_start
     type: IDS2jetto-variable
     paths:
-      - ids: t0
-        path: does-not-exist/0
-    default: null
+      - {ids: t0, path: does-not-exist/0}
     """)
     }
 
@@ -98,16 +91,11 @@ def test_conditionals(var):
     name: ids-t_start
     type: IDS2jetto-variable
     paths:
-      - ids: t0
-        path: time/0
-      - ids: t1
-        path: time/1
-    default: null
+      - {ids: t0, path: time/0}
+      - {ids: t1, path: time/1}
     accept_if:
-      - operator: ne
-        args: [10]
-      - operator: gt
-        args: [0]
+      - {operator: ne, args: [10]}
+      - {operator: gt, args: [0]}
     """)
     }
 
@@ -127,3 +115,24 @@ def test_getattr(var):
     # ensure that default attribute lookup does not fail
     var.moo = 123
     assert var.moo == 123
+
+
+def test_caching(var):
+    lookup = {
+        'ids-t_start':
+        IDS2JettoVariableModel.parse_raw("""
+    name: ids-t_start
+    type: IDS2jetto-variable
+    paths:
+      - {ids: t0, path: time/0}
+      - {ids: t1, path: time/1}
+    """)
+    }
+
+    var.lookup = lookup
+    assert not var._ids_cache
+
+    var.t_start
+
+    assert 't0' in var._ids_cache
+    assert 't1' not in var._ids_cache


### PR DESCRIPTION
This PR adds a schema and lookup-table for IDS-to-jetto variables so that they can be accessed from `duqduq setup` template.

I move all the data specification to `ids2jetto_variables.yaml`. A variables class is passed to the `duqduq setup` template. Attributes on that class are dynamically looked up. This means that definition of new variable can be done completely through yaml.

I have prefixed all the variables with `IDS_` to distinguish them from the variables in `variables.yaml`. I'm not entirely happy with this, but I can't think of a better way of doing this.

Documentation is a bit out of date, but I will update that next.

Closes #501