### PR TITLE
Add tag to config schema to name jobs/runs

### DIFF
--- a/src/duqtools/create.py
+++ b/src/duqtools/create.py
@@ -160,7 +160,13 @@ class CreateManager:
     @add_to_op_queue('Writing csv', quiet=True)
     def write_runs_csv(self, runs: Sequence[Run]):
         fname = self.data_csv
-        run_map = {run.dirname: run.data_out.dict() for run in runs}
+
+        prefix = f'{cfg.tag}.' if cfg.tag else ''
+
+        run_map = {
+            f'{prefix}{run.shortname}': run.data_out.dict()
+            for run in runs
+        }
         df = pd.DataFrame.from_dict(run_map, orient='index')
         df.to_csv(fname)
 

--- a/src/duqtools/jetto/_llcmd.py
+++ b/src/duqtools/jetto/_llcmd.py
@@ -9,14 +9,23 @@ import jetto_tools
 from ..models import Locations
 
 
-def write_batchfile(run_dir: Path, jset: jetto_tools.jset.JSET):
+def write_batchfile(run_dir: Path,
+                    jset: jetto_tools.jset.JSET,
+                    tag: str | None = None):
     """Write batchfile (`.llcmd`) to start jetto.
 
     Parameters
     ----------
-    target_drc : Path
+    run_dir : Path
         Directory to place batch file into.
+    jset: JSET
+        Jetto settings object (from jetto-pythontools)
+    tag : str | None
+        Tag the job, defaults to 'jetto'.
     """
+    if not tag:
+        tag = 'jetto'
+
     llcmd_path = run_dir / '.llcmd'
 
     rjettov_path = run_dir / 'rjettov'
@@ -30,7 +39,7 @@ def write_batchfile(run_dir: Path, jset: jetto_tools.jset.JSET):
 
     with open(llcmd_path, 'w') as f:
         f.write(f"""#!/bin/sh
-#SBATCH -J duqtools.jetto.{run_dir.name}
+#SBATCH -J duqtools.{tag}.{run_dir.name}
 #SBATCH -i /dev/null
 #SBATCH -o {run_dir / 'll.out'}
 #SBATCH -e {run_dir / 'll.err'}

--- a/src/duqtools/jetto/_system.py
+++ b/src/duqtools/jetto/_system.py
@@ -70,16 +70,19 @@ class BaseJettoSystem(AbstractSystem):
         if (job.dir / 'jetto.status').exists():
             os.remove(job.dir / 'jetto.status')
 
-        if cfg.submit.submit_system == 'slurm':
-            JettoSystem.submit_slurm(job)
-        elif cfg.submit.submit_system == 'docker':
-            JettoSystem.submit_docker(job)
-        elif cfg.submit.submit_system == 'prominence':
-            JettoSystem.submit_prominence(job)
+        submit_system = cfg.submit.submit_system
+
+        if submit_system == 'slurm':
+            submit = JettoSystem.submit_slurm
+        elif submit_system == 'docker':
+            submit = JettoSystem.submit_docker
+        elif submit_system == 'prominence':
+            submit = JettoSystem.submit_prominence
         else:
-            raise NotImplementedError(
-                'submission type {cfg.submit.submit_system}'
-                ' not implemented')
+            raise NotImplementedError(f'submission type {submit_system}'
+                                      ' not implemented')
+
+        submit(job)
 
     @staticmethod
     def submit_slurm(job: Job):

--- a/src/duqtools/jetto/_system.py
+++ b/src/duqtools/jetto/_system.py
@@ -61,8 +61,7 @@ class BaseJettoSystem(AbstractSystem):
     @add_to_op_queue('Writing new batchfile', '{run_dir.name}', quiet=True)
     def write_batchfile(run_dir: Path):
         jetto_jset = jset.read(run_dir / 'jetto.jset')
-
-        jetto_write_batchfile(run_dir, jetto_jset)
+        jetto_write_batchfile(run_dir, jetto_jset, tag=cfg.tag)
 
     @staticmethod
     def submit_job(job: Job):

--- a/src/duqtools/schema/cli.py
+++ b/src/duqtools/schema/cli.py
@@ -153,6 +153,11 @@ class StatusConfigModel(BaseModel):
 
 class ConfigModel(BaseModel):
     """The options for the CLI are defined by this model."""
+    tag: str = Field(
+        '',
+        description=
+        'Create a tag for the runs to identify them in slurm or `data.csv`')
+
     submit: SubmitConfigModel = Field(
         SubmitConfigModel(),
         description='Configuration for the submit subcommand')


### PR DESCRIPTION
This PR adds a 'tag' option to the root config. This can be used to name 

The tag gets propagated to `data.csv` and the job name in `.llcmd`. But it can also be useful elsewhere.

Addresses #432 