### PR TITLE
Add fine-grained status reports for duqduq and improve efficiency

### DIFF
--- a/src/duqtools/large_scale_validation/cli.py
+++ b/src/duqtools/large_scale_validation/cli.py
@@ -17,11 +17,6 @@ except ImportError:
 def cli_entry():
     from duqtools import fix_dependencies
     fix_dependencies()
-    click.secho(
-        'Note: This tool is a work in progress and not ready to be used.',
-        bold=True,
-        bg='red',
-        fg='white')
     cli()
 
 

--- a/src/duqtools/large_scale_validation/status.py
+++ b/src/duqtools/large_scale_validation/status.py
@@ -22,7 +22,7 @@ def status(*, progress: bool, detailed: bool, **kwargs):
 
     config_files = cwd.glob('**/duqtools.yaml')
 
-    jobs: list[Job] = []
+    all_jobs: list[Job] = []
 
     click.echo(Job.symbol_help())
     click.echo()
@@ -36,18 +36,18 @@ def status(*, progress: bool, detailed: bool, **kwargs):
 
         config_dir = config_file.parent
 
-        new_jobs = [Job(run.dirname) for run in Locations(config_dir).runs]
-        jobs.extend(new_jobs)
+        jobs = [Job(run.dirname) for run in Locations(config_dir).runs]
+        all_jobs.extend(jobs)
 
         name = config_file.parent.name
         tag = cfg.tag
-        status = ''.join(sorted(job.symbol for job in new_jobs))
+        status = ''.join(job.symbol for job in jobs)
 
         click.echo(f'{name} ({tag}): {status}')
 
     click.echo()
 
-    tracker = Status(jobs)
+    tracker = Status(all_jobs)
 
     if detailed:
         tracker.detailed_status()

--- a/src/duqtools/large_scale_validation/status.py
+++ b/src/duqtools/large_scale_validation/status.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import click
+
 from ..config import cfg
 from ..models import Job, Locations
 from ..status import Status, StatusError
@@ -22,6 +24,9 @@ def status(*, progress: bool, detailed: bool, **kwargs):
 
     jobs: list[Job] = []
 
+    click.echo(Job.symbol_help())
+    click.echo()
+
     for config_file in config_files:
         cfg.parse_file(config_file)
 
@@ -38,9 +43,9 @@ def status(*, progress: bool, detailed: bool, **kwargs):
         tag = cfg.tag
         status = ''.join(sorted(job.symbol for job in new_jobs))
 
-        print(f'{name} ({tag}): {status}')
+        click.echo(f'{name} ({tag}): {status}')
 
-    print()
+    click.echo()
 
     tracker = Status(jobs)
 

--- a/src/duqtools/large_scale_validation/status.py
+++ b/src/duqtools/large_scale_validation/status.py
@@ -24,7 +24,7 @@ def status(*, progress: bool, detailed: bool, **kwargs):
 
     all_jobs: list[Job] = []
 
-    click.echo(Job.symbol_help())
+    click.echo(Job.status_symbol_help())
     click.echo()
 
     for config_file in config_files:
@@ -41,7 +41,7 @@ def status(*, progress: bool, detailed: bool, **kwargs):
 
         name = config_file.parent.name
         tag = cfg.tag
-        status = ''.join(job.symbol for job in jobs)
+        status = ''.join(job.status_symbol for job in jobs)
 
         click.echo(f'{name} ({tag}): {status}')
 

--- a/src/duqtools/large_scale_validation/status.py
+++ b/src/duqtools/large_scale_validation/status.py
@@ -31,7 +31,16 @@ def status(*, progress: bool, detailed: bool, **kwargs):
 
         config_dir = config_file.parent
 
-        jobs.extend(Job(run.dirname) for run in Locations(config_dir).runs)
+        new_jobs = [Job(run.dirname) for run in Locations(config_dir).runs]
+        jobs.extend(new_jobs)
+
+        name = config_file.parent.name
+        tag = cfg.tag
+        status = ''.join(sorted(job.symbol for job in new_jobs))
+
+        print(f'{name} ({tag}): {status}')
+
+    print()
 
     tracker = Status(jobs)
 

--- a/src/duqtools/models/__init__.py
+++ b/src/duqtools/models/__init__.py
@@ -1,4 +1,4 @@
-from ._job import Job
+from ._job import Job, JobStatus
 from ._locations import Locations
 from ._system import AbstractSystem
 
@@ -6,4 +6,5 @@ __all__ = [
     'Locations',
     'AbstractSystem',
     'Job',
+    'JobStatus',
 ]

--- a/src/duqtools/models/_job.py
+++ b/src/duqtools/models/_job.py
@@ -19,6 +19,21 @@ class Job:
         return f'{self.__class__.__name__}({run!r})'
 
     @property
+    def symbol(self):
+        """One letter status symbol
+        c: completed, f: failed, r: running, s: submitted, _: no status, 'u': unknown.
+        """
+        status_codes = {
+            'no status': '_',
+            'completed': 'c',
+            'failed': 'f',
+            'running': 'r',
+            'submitted': 's',
+            'unknown': 'u'
+        }
+        return status_codes[self.status()]
+
+    @property
     def has_submit_script(self) -> bool:
         return self.submit_script.exists()
 

--- a/src/duqtools/models/_job.py
+++ b/src/duqtools/models/_job.py
@@ -8,6 +8,17 @@ from ..config import cfg
 logger = logging.getLogger(__name__)
 info, debug = logger.info, logger.debug
 
+cs = click.style
+
+STATUS_CODES = {
+    'no status': cs('_', fg='yellow'),
+    'completed': cs('.', fg='green'),
+    'failed': cs('f', fg='red'),
+    'running': cs('r', fg='yellow'),
+    'submitted': cs('s', fg='yellow'),
+    'unknown': cs('u', fg='yellow')
+}
+
 
 class Job:
 
@@ -18,20 +29,17 @@ class Job:
         run = str(self.dir)
         return f'{self.__class__.__name__}({run!r})'
 
+    @staticmethod
+    def symbol_help():
+        """Return help string for status codes."""
+        s = ', '.join(f'{code} : {status}'
+                      for status, code in STATUS_CODES.items())
+        return f'Status codes:\n{s}'
+
     @property
     def symbol(self):
-        """One letter status symbol
-        c: completed, f: failed, r: running, s: submitted, _: no status, 'u': unknown.
-        """
-        status_codes = {
-            'no status': '_',
-            'completed': 'c',
-            'failed': 'f',
-            'running': 'r',
-            'submitted': 's',
-            'unknown': 'u'
-        }
-        return status_codes[self.status()]
+        """One letter status symbol."""
+        return STATUS_CODES[self.status()]
 
     @property
     def has_submit_script(self) -> bool:

--- a/src/duqtools/models/_job.py
+++ b/src/duqtools/models/_job.py
@@ -30,25 +30,36 @@ class Job:
     def is_submitted(self) -> bool:
         return (self.dir / 'duqtools.submit.lock').exists()
 
-    def status_file_contains(self, msg) -> bool:
+    def status(self) -> str:
+        if not self.has_status:
+            return 'no status'
+
         sf = self.status_file
         with open(sf) as f:
             content = f.read()
-            debug('Checking if content of %s file: %s contains %s', sf,
-                  content, msg)
-            return msg in content
+            if cfg.status.msg_completed in content:
+                return 'completed'
+            elif cfg.status.msg_failed in content:
+                return 'failed'
+            elif cfg.status.msg_running in content:
+                return 'running'
+
+        if not self.is_submitted:
+            return 'unsubmitted'
+
+        return 'unknown'
 
     @property
     def is_completed(self) -> bool:
-        return self.status_file_contains(cfg.status.msg_completed)
+        return self.status == 'completed'
 
     @property
     def is_failed(self) -> bool:
-        return self.status_file_contains(cfg.status.msg_failed)
+        return self.status == 'failed'
 
     @property
     def is_running(self) -> bool:
-        return self.status_file_contains(cfg.status.msg_running)
+        return self.status == 'running'
 
     @property
     def in_file(self) -> Path:

--- a/src/duqtools/status.py
+++ b/src/duqtools/status.py
@@ -146,8 +146,7 @@ class Monitor():
     def set_status(self):
         status = self.job.status()
 
-        self.pbar.set_description(
-            f'{self.job.dir.name:8s}, status: {status:12s}')
+        self.pbar.set_description(f'{self.job.dir.name:8s}, {status:12s}')
         self.pbar.refresh()
 
         return status

--- a/src/duqtools/status.py
+++ b/src/duqtools/status.py
@@ -1,5 +1,6 @@
 import logging
 import subprocess as sp
+from collections import Counter
 from time import sleep
 from typing import Sequence
 
@@ -22,13 +23,13 @@ class StatusError(Exception):
 
 class Status():
 
-    jobs: list
-    jobs_submit: list
-    jobs_submitted: list
-    jobs_status: list
-    jobs_failed: list
-    jobs_running: list
-    jobs_unknown: list
+    jobs: Sequence[Job]
+    jobs_submit: int
+    jobs_submitted: int
+    jobs_status: int
+    jobs_failed: int
+    jobs_running: int
+    jobs_unknown: int
 
     def __init__(self, jobs=Sequence[Job]):
         self.jobs = jobs
@@ -39,57 +40,47 @@ class Status():
 
     def update_status(self):
 
-        self.jobs_submit = [job for job in self.jobs if job.has_submit_script]
-        self.jobs_status = [job for job in self.jobs if job.has_status]
-        self.jobs_submitted = [job for job in self.jobs if job.is_submitted]
+        self.n_submit_script = sum(job.has_submit_script for job in self.jobs)
+        self.n_status = sum(job.has_status for job in self.jobs)
 
-        self.jobs_completed = [
-            job for job in self.jobs_status if job.is_completed
-        ]
-        self.jobs_failed = [job for job in self.jobs_status if job.is_failed]
-        self.jobs_running = [job for job in self.jobs_status if job.is_running]
+        counter = Counter(job.status() for job in self.jobs)
 
-        self.jobs_unknown = [
-            job for job in self.jobs_status
-            if not (job in self.jobs_completed or job in self.jobs_failed
-                    or job in self.jobs_running)
-        ]
+        self.n_submitted = counter['submitted']
+        self.n_completed = counter['completed']
+        self.n_running = counter['running']
+        self.n_failed = counter['failed']
+        self.n_unknown = counter['unknown']
 
     def simple_status(self):
         """stateless status."""
-
         self.update_status()
-        info('Total number of directories with submission script : %i',
-             len(self.jobs_submit))
-        info('      number of not submitted jobs                 : %i',
-             (len(self.jobs_submit) - len(self.jobs_status)))
-        info('Total number of directories with status     script : %i',
-             len(self.jobs_status))
-        info('Total number of directories with Completed status  : %i',
-             len(self.jobs_completed))
-        info('Total number of directories with Failed    status  : %i',
-             len(self.jobs_failed))
-        info('Total number of directories with Running   status  : %i',
-             len(self.jobs_running))
-        info('Total number of directories with Unknown   status  : %i',
-             len(self.jobs_unknown))
+
+        msg = 'Total number of directories with %-17s : %i'
+
+        info(msg, 'submit script', self.n_submit_script)
+        info(msg, 'unsubmitted jobs', self.n_submit_script - self.n_status)
+        info(msg, 'status script', self.n_status)
+        info(msg, 'completed status', self.n_completed)
+        info(msg, 'failed status', self.n_failed)
+        info(msg, 'running status', self.n_running)
+        info(msg, 'unknown status', self.n_unknown)
 
     def progress_status(self):
         """Monitor the directory for status changes."""
         from tqdm import tqdm
         pbar_a = tqdm(total=len(self.jobs), position=0)
         pbar_a.set_description('Submitted jobs            ...')
-        pbar_b = tqdm(total=len(self.jobs_submit), position=1)
+        pbar_b = tqdm(total=self.n_submit_script, position=1)
         pbar_b.set_description('Running jobs              ...')
-        pbar_c = tqdm(total=len(self.jobs_submit), position=2)
+        pbar_c = tqdm(total=self.n_submit_script, position=2)
         pbar_c.set_description('Completed jobs            ...')
-        pbar_d = tqdm(total=len(self.jobs_submit), position=3)
+        pbar_d = tqdm(total=self.n_submit_script, position=3)
         pbar_d.set_description('Failed? jobs              ...')
-        while len(self.jobs_completed) < len(self.jobs_submit):
-            pbar_a.n = len(self.jobs_submitted)
-            pbar_b.n = len(self.jobs_running)
-            pbar_c.n = len(self.jobs_completed)
-            pbar_d.n = len(self.jobs_failed) + len(self.jobs_unknown)
+        while self.n_completed < self.n_submit_script:
+            pbar_a.n = self.n_submitted
+            pbar_b.n = self.n_running
+            pbar_c.n = self.n_completed
+            pbar_d.n = self.n_failed + self.n_unknown
             pbar_a.refresh()
             pbar_b.refresh()
             pbar_c.refresh()
@@ -153,22 +144,13 @@ class Monitor():
             raise StatusError(msg)
 
     def set_status(self):
-        if not self.job.has_status:
-            status = 'No status'
-        elif self.job.is_running:
-            status = 'Running     '
-        elif self.job.is_failed:
-            status = 'FAILED      '
-        elif self.job.is_completed:
-            status = 'COMPLETED   '
-        elif not self.job.is_submitted:
-            status = 'Unsubmitted '
-        else:
-            status = 'UNKNOWN'
+        status = self.job.status()
 
         self.pbar.set_description(
             f'{self.job.dir.name:8s}, status: {status:12s}')
         self.pbar.refresh()
+
+        return status
 
     def get_steptime(self):
         if not self.job.out_file.exists():
@@ -184,15 +166,14 @@ class Monitor():
         return None
 
     def update(self):
-        self.set_status()
-        if self.job.has_status:
-            if self.job.is_completed or self.job.is_failed:
-                self.pbar.n = 100 if self.job.is_completed else 0
-                self.pbar.refresh()
-                self.finished = True
-                return
-            if not self.job.is_running:
-                return
+        status = self.set_status()
+        if status in ('completed', 'failed'):
+            self.pbar.n = 100 if status == 'completed' else 0
+            self.pbar.refresh()
+            self.finished = True
+            return
+        if not self.job.is_running:
+            return
 
         steptime = self.get_steptime()
         if steptime:

--- a/src/duqtools/status.py
+++ b/src/duqtools/status.py
@@ -8,7 +8,7 @@ from jetto_tools import config, template
 
 from .config import cfg
 from .jetto._system import jetto_lookup
-from .models import Job, Locations
+from .models import Job, JobStatus, Locations
 
 logger = logging.getLogger(__name__)
 info, debug = logger.info, logger.debug
@@ -45,11 +45,11 @@ class Status():
 
         counter = Counter(job.status() for job in self.jobs)
 
-        self.n_submitted = counter['submitted']
-        self.n_completed = counter['completed']
-        self.n_running = counter['running']
-        self.n_failed = counter['failed']
-        self.n_unknown = counter['unknown']
+        self.n_submitted = counter[JobStatus.SUBMITTED]
+        self.n_completed = counter[JobStatus.COMPLETED]
+        self.n_running = counter[JobStatus.RUNNING]
+        self.n_failed = counter[JobStatus.FAILED]
+        self.n_unknown = counter[JobStatus.UNKNOWN]
 
     def simple_status(self):
         """stateless status."""
@@ -166,12 +166,12 @@ class Monitor():
 
     def update(self):
         status = self.set_status()
-        if status in ('completed', 'failed'):
-            self.pbar.n = 100 if status == 'completed' else 0
+        if status in (JobStatus.COMPLETED, JobStatus.FAILED):
+            self.pbar.n = 100 if status == JobStatus.COMPLETED else 0
             self.pbar.refresh()
             self.finished = True
             return
-        if not self.job.is_running:
+        if not status == JobStatus.RUNNING:
             return
 
         steptime = self.get_steptime()

--- a/src/duqtools/submit.py
+++ b/src/duqtools/submit.py
@@ -25,18 +25,26 @@ def Spinner(frames='⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏'):
 
 
 @add_to_op_queue('Submitting', '{job}')
-def _submit_job(job: Job):
+def _submit_job(job: Job, *, delay: float = 0):
+    """
+    Parameters
+    ----------
+    delay : float
+        Add a delay to avoid all jobs starting at the same time.
+        This causes issues with slurm, for example.
+    """
+    if delay:
+        time.sleep(delay)
     job.submit()
 
 
 def job_submitter(jobs: Sequence[Job], *, max_jobs):
     for n, job in enumerate(jobs):
-
         if max_jobs and (n >= max_jobs):
             info(f'Max jobs ({max_jobs}) reached.')
             break
 
-        _submit_job(job)
+        _submit_job(job, delay=0.1)
 
 
 @add_to_op_queue('Start job scheduler')
@@ -53,6 +61,8 @@ def job_scheduler(queue: Deque[Job], max_jobs=10):
             job = queue.popleft()
             task = job.start()
             tasks.append(task)
+            # starting jobs at the same time causes issues
+            time.sleep(0.1)
 
         time.sleep(interval)
         task = tasks.popleft()


### PR DESCRIPTION
This PR refactors the status file handling for status reporting to reduce the number of file reads by about 80%. This should make the status report significantly more efficient. This PR also adds more fine-grained status reporting for duqduq. For each data entry, a short line with the summary for each run gets printed.

Addresses #432 