### PR TITLE
Submit status filter

### DIFF
--- a/src/duqtools/cli.py
+++ b/src/duqtools/cli.py
@@ -278,6 +278,12 @@ def cli_recreate(**kwargs):
               default=tuple(),
               type=Path,
               help='Case to re-submit, can be specified multiple times')
+@click.option('-s',
+              '--status',
+              'status_filter',
+              type=str,
+              multiple=True,
+              help='Only submit jobs with this status.')
 @common_options(*all_options)
 def cli_submit(**kwargs):
     """Submit the UQ runs.

--- a/src/duqtools/large_scale_validation/cli.py
+++ b/src/duqtools/large_scale_validation/cli.py
@@ -80,6 +80,12 @@ def cli_create(**kwargs):
               '--max_jobs',
               type=int,
               help='Maximum number of jobs to submit.')
+@click.option('-s',
+              '--status',
+              'status_filter',
+              type=str,
+              multiple=True,
+              help='Only submit jobs with this status.')
 @click.option('-a', '--array', is_flag=True, help='Submit jobs as array.')
 @common_options(*logging_options, yes_option)
 def cli_submit(**kwargs):

--- a/src/duqtools/large_scale_validation/submit.py
+++ b/src/duqtools/large_scale_validation/submit.py
@@ -1,6 +1,6 @@
 from collections import deque
 from pathlib import Path
-from typing import Deque
+from typing import Deque, Sequence
 
 from ..config import cfg
 from ..models import Job, Locations
@@ -14,7 +14,8 @@ from ..submit import (
 )
 
 
-def submit(*, array, force, max_jobs, schedule, status_filter, **kwargs):
+def submit(*, array, force, max_jobs, schedule, status_filter: Sequence[str],
+           **kwargs):
     """Submit nested duqtools configs.
 
     Parameters
@@ -33,7 +34,7 @@ def submit(*, array, force, max_jobs, schedule, status_filter, **kwargs):
 
     config_files = cwd.glob('**/duqtools.yaml')
 
-    jobs = []
+    jobs: list[Job] = []
 
     for config_file in config_files:
         cfg.parse_file(config_file)

--- a/src/duqtools/large_scale_validation/submit.py
+++ b/src/duqtools/large_scale_validation/submit.py
@@ -14,7 +14,7 @@ from ..submit import (
 )
 
 
-def submit(*, array, force, max_jobs, schedule, **kwargs):
+def submit(*, array, force, max_jobs, schedule, status_filter, **kwargs):
     """Submit nested duqtools configs.
 
     Parameters
@@ -26,6 +26,8 @@ def submit(*, array, force, max_jobs, schedule, **kwargs):
     schedule : bool
         Schedule `max_jobs` to run at once, keeps the process alive until
         finished.
+    status_filter : list[str]
+        Only submit jobs with this status.
     """
     cwd = Path.cwd()
 
@@ -47,6 +49,10 @@ def submit(*, array, force, max_jobs, schedule, **kwargs):
     job_queue: Deque[Job] = deque()
 
     for job in jobs:
+        status = job.status()
+
+        if status not in status_filter:
+            continue
         if not status_file_ok(job, force=force):
             continue
         if not lockfile_ok(job, force=force):

--- a/src/duqtools/submit.py
+++ b/src/duqtools/submit.py
@@ -162,6 +162,7 @@ def submit(*,
            schedule: bool,
            array: bool,
            resubmit: Sequence[Path] = (),
+           status_filter: Sequence[str],
            **kwargs):
     """submit. Function which implements the functionality to submit jobs to
     the cluster.
@@ -181,6 +182,8 @@ def submit(*,
         If any jobs need to be resubmitted, this is has a nonzero length, and
         contains a Sequence of Paths which either are the full Path to the run
         that needs to be resubmitted, or the shortname
+    status_filter : list[str]
+        Only submit jobs with this status.
     """
     if not cfg.submit:
         raise SubmitError('Submit field required in config file')
@@ -198,6 +201,10 @@ def submit(*,
     job_queue: Deque[Job] = deque()
 
     for job in jobs:
+        status = job.status()
+
+        if status not in status_filter:
+            continue
         if not status_file_ok(job, force=force):
             continue
         if not lockfile_ok(job, force=force):


### PR DESCRIPTION
This PR implements a status filter for `duqduq submit` or `duqtools submit`, so you can do `duqtools submit --status 'no status'` to resubmit those jobs. The argument can be stacked, so you can filter multiple statuses `duqtools submit --status 'no status' --status failed`.