### PR TITLE
Bugfix: do not filter if filter is empty

### DIFF
--- a/src/duqtools/large_scale_validation/submit.py
+++ b/src/duqtools/large_scale_validation/submit.py
@@ -52,7 +52,7 @@ def submit(*, array, force, max_jobs, schedule, status_filter: Sequence[str],
     for job in jobs:
         status = job.status()
 
-        if status not in status_filter:
+        if status_filter and (status not in status_filter):
             continue
         if not status_file_ok(job, force=force):
             continue

--- a/src/duqtools/submit.py
+++ b/src/duqtools/submit.py
@@ -203,7 +203,7 @@ def submit(*,
     for job in jobs:
         status = job.status()
 
-        if status not in status_filter:
+        if status_filter and (status not in status_filter):
             continue
         if not status_file_ok(job, force=force):
             continue


### PR DESCRIPTION
This PR fixes a but where no jobs would be submitted if the status filter is empty (the default).