### PR TITLE
Force output of imas data

### DIFF
--- a/src/duqtools/jetto/_system.py
+++ b/src/duqtools/jetto/_system.py
@@ -183,7 +183,7 @@ class BaseJettoSystem(AbstractSystem):
         """Apply settings that are necessary for duqtools to function."""
         # Force output of IDS data
         # https://github.com/duqtools/duqtools/issues/343
-        jetto_template.jset._settings['JobProcessingPanel.selIdsRunid'] = False
+        jetto_template.jset._settings['JobProcessingPanel.selIdsRunid'] = True
 
     @staticmethod
     @add_to_op_queue('Copying template to', '{target_drc}', quiet=True)


### PR DESCRIPTION
This PR makes sure the `JobProcessingPanel.selIdsRunid` is set to True. This adds the `IDSOUT` job to `jintrac_imas_config.cfg`, which triggers writing of IDS files.

For reference, this done by `createworkflow_cfg`:
```
IDSOUT_STATUS=`getvalue "JobProcessingPanel.selIdsRunid" $SETTINGS`
        if [ "$IDSOUT_STATUS" = "true" ] ; then
            COMPONENTS=$COMPONENTS",IDSOUT"
        fi
```

Closes #526