### PR TITLE
Revert tests to use `containerized_runs/main`

### DIFF
--- a/.github/workflows/test_imas.yaml
+++ b/.github/workflows/test_imas.yaml
@@ -37,7 +37,6 @@ jobs:
         with:
           ssh-key: ${{ secrets.SSH_KEY_CONTAINERIZED_RUNS_REPO }}
           repository: duqtools/containerized_runs
-          ref: aarons_runs
           path: containerized_runs
 
       - name: Put the IMAS db in the right location

--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,7 @@ celerybeat.pid
 .env
 .venv
 .docker
+.imasenv
 .imas_env
 .imas
 env/

--- a/example/duqtools.yaml
+++ b/example/duqtools.yaml
@@ -1,16 +1,16 @@
 create:
   dimensions:
   - values:
+    - 0.8
     - 1.0
-    - 1.00001
-    - 1.00002
+    - 1.2
     operator: multiply
     scale_to_error: false
     variable: t_e
   - values:
+    - 0.8
     - 1.0
-    - 1.00001
-    - 1.00002
+    - 1.2
     operator: multiply
     scale_to_error: false
     variable: zeff

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -49,7 +49,7 @@ def cmdline_workdir(tmp_path_factory, system):
     yield workdir
 
     if system == 'v210921':
-        for i in range(3):
+        for i in range(2):
             p = Path(cmdline_workdir,
                      f'run_000{i}/imasdb/test/3/0/ids_111110001.datafile')
             p.unlink()
@@ -63,7 +63,7 @@ def test_example_create(cmdline_workdir, system):
         result = sp.run(cmd)
         assert (result.returncode == 0)
 
-        for i in range(3):
+        for i in range(2):
             if system == 'jetto-v210921':
                 p = Path(
                     f'/opt/imas/shared/imasdb/test/3/0/ids_11111700{i}.datafile'

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -51,7 +51,7 @@ def cmdline_workdir(tmp_path_factory, system):
     if system == 'v210921':
         for i in range(2):
             p = Path(cmdline_workdir,
-                     f'run_000{i}/imasdb/test/3/0/ids_111110001.datafile')
+                     f'run_000{i}/imasdb/jet/3/0/ids_1230001.datafile')
             p.unlink()
 
 
@@ -66,11 +66,11 @@ def test_example_create(cmdline_workdir, system):
         for i in range(2):
             if system == 'jetto-v210921':
                 p = Path(
-                    f'/opt/imas/shared/imasdb/test/3/0/ids_11111700{i}.datafile'
+                    f'/opt/imas/shared/imasdb/jet/3/0/ids_123070{i}.datafile'
                 )
             else:
                 p = Path(cmdline_workdir,
-                         f'run_000{i}/imasdb/test/3/0/ids_111110001.datafile')
+                         f'run_000{i}/imasdb/jet/3/0/ids_1230001.datafile')
             assert p.exists()
 
 
@@ -79,10 +79,10 @@ def test_example_recreate(cmdline_workdir, system):
     cmd = 'duqtools recreate run_0000 -c config.yaml --yes'.split()
 
     if system == 'jetto-v210921':
-        p = Path('/opt/imas/shared/imasdb/test/3/0/ids_111117000.datafile')
+        p = Path('/opt/imas/shared/imasdb/jet/3/0/ids_1230700.datafile')
     else:
         p = Path(cmdline_workdir,
-                 'run_0000/imasdb/test/3/0/ids_111110001.datafile')
+                 'run_0000/imasdb/jet/3/0/ids_1230001.datafile')
 
     p.unlink()
     assert not p.exists()
@@ -144,7 +144,7 @@ def test_example_plot(cmdline_workdir):
     if imas_mocked:
         pytest.xfail('Imas needed for plotting Imas data')
 
-    cmd = ('duqtools plot -h public/test/11111/6666 -v zeff').split()
+    cmd = ('duqtools plot -h public/jet/123/1 -v zeff').split()
 
     with work_directory(cmdline_workdir):
         result = sp.run(cmd)

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -51,7 +51,7 @@ def cmdline_workdir(tmp_path_factory, system):
     if system == 'v210921':
         for i in range(3):
             p = Path(cmdline_workdir,
-                     f'run_000{i}/imasdb/jet/3/0/ids_111110001.datafile')
+                     f'run_000{i}/imasdb/test/3/0/ids_111110001.datafile')
             p.unlink()
 
 
@@ -66,11 +66,11 @@ def test_example_create(cmdline_workdir, system):
         for i in range(3):
             if system == 'jetto-v210921':
                 p = Path(
-                    f'/opt/imas/shared/imasdb/jet/3/0/ids_90350700{i}.datafile'
+                    f'/opt/imas/shared/imasdb/test/3/0/ids_11111700{i}.datafile'
                 )
             else:
                 p = Path(cmdline_workdir,
-                         f'run_000{i}/imasdb/jet/3/0/ids_903500001.datafile')
+                         f'run_000{i}/imasdb/test/3/0/ids_111110001.datafile')
             assert p.exists()
 
 
@@ -79,10 +79,10 @@ def test_example_recreate(cmdline_workdir, system):
     cmd = 'duqtools recreate run_0000 -c config.yaml --yes'.split()
 
     if system == 'jetto-v210921':
-        p = Path('/opt/imas/shared/imasdb/jet/3/0/ids_903507000.datafile')
+        p = Path('/opt/imas/shared/imasdb/test/3/0/ids_111117000.datafile')
     else:
         p = Path(cmdline_workdir,
-                 'run_0000/imasdb/jet/3/0/ids_903500001.datafile')
+                 'run_0000/imasdb/test/3/0/ids_111110001.datafile')
 
     p.unlink()
     assert not p.exists()
@@ -144,7 +144,7 @@ def test_example_plot(cmdline_workdir):
     if imas_mocked:
         pytest.xfail('Imas needed for plotting Imas data')
 
-    cmd = ('duqtools plot -h public/jet/90350/2 -v zeff').split()
+    cmd = ('duqtools plot -h public/test/11111/6666 -v zeff').split()
 
     with work_directory(cmdline_workdir):
         result = sp.run(cmd)

--- a/tests/test_data/config_jetto.yaml
+++ b/tests/test_data/config_jetto.yaml
@@ -16,7 +16,7 @@ create:
     variable: zeff
   sampler:
     method: latin-hypercube
-    n_samples: 3
+    n_samples: 2
   data:
     user: public
     imasdb: test

--- a/tests/test_data/config_jetto.yaml
+++ b/tests/test_data/config_jetto.yaml
@@ -19,15 +19,15 @@ create:
     n_samples: 2
   data:
     user: public
-    imasdb: test
-    run_in_start_at: 7000
-    run_out_start_at: 8000
+    imasdb: jet
+    run_in_start_at: 700
+    run_out_start_at: 800
   template: ./template_model
   template_data:
     user: public
-    db: test
-    shot: 11111
-    run: 6666
+    db: jet
+    shot: 123
+    run: 1
 extra_variables:
   - name: my_extra_var
     ids: core_profiles

--- a/tests/test_data/config_jetto.yaml
+++ b/tests/test_data/config_jetto.yaml
@@ -25,9 +25,9 @@ create:
   template: ./template_model
   template_data:
     user: public
-    db: jet
-    shot: 90350
-    run: 2
+    db: test
+    shot: 11111
+    run: 6666
 extra_variables:
   - name: my_extra_var
     ids: core_profiles

--- a/tests/test_data/config_jetto.yaml
+++ b/tests/test_data/config_jetto.yaml
@@ -19,7 +19,7 @@ create:
     n_samples: 3
   data:
     user: public
-    imasdb: jet
+    imasdb: test
     run_in_start_at: 7000
     run_out_start_at: 8000
   template: ./template_model

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -45,7 +45,6 @@ def test_clean_database(cmdline_workdir):
                   standalone_mode=False)
         assert (not Path('./run_0000').exists())
         assert (not Path('./run_0001').exists())
-        assert (not Path('./run_0002').exists())
         assert (not Path('./runs.yaml').exists())
         assert (Path('./runs.yaml.old').exists())
 
@@ -63,7 +62,6 @@ def test_create(cmdline_workdir):
                    standalone_mode=False)
         assert (not Path('./run_0000').exists())
         assert (not Path('./run_0001').exists())
-        assert (not Path('./run_0002').exists())
         assert (not Path('./runs.yaml').exists())
 
 
@@ -75,7 +73,6 @@ def test_real_create(cmdline_workdir):
                    standalone_mode=False)
         assert (Path('./run_0000').exists())
         assert (Path('./run_0001').exists())
-        assert (Path('./run_0002').exists())
         assert (Path('./runs.yaml').exists())
 
 
@@ -85,7 +82,6 @@ def test_submit(cmdline_workdir):
         cli_submit(['-c', 'config.yaml', '--dry-run'], standalone_mode=False)
         assert (not Path('./run_0000/duqtools.lock').exists())
         assert (not Path('./run_0001/duqtools.lock').exists())
-        assert (not Path('./run_0002/duqtools.lock').exists())
 
 
 @pytest.mark.xfail(reason='https://github.com/duqtools/duqtools/issues/257')


### PR DESCRIPTION
This PR reverts the tests to use the main branch of `https://github.com/duqtools/containerized_runs` for our CI now that `v220922` is working.

### Todo

- [x] Remove extra branch from containerized_runs repo(?)