### PR TITLE
Add path and imas filters for duqduq create and submit

### DIFF
--- a/src/duqtools/large_scale_validation/cli.py
+++ b/src/duqtools/large_scale_validation/cli.py
@@ -67,6 +67,11 @@ def cli_setup(**kwargs):
     help=
     'Only create data for configs in subdirectories matching this glob pattern.'
 )
+@click.option('-i',
+              '--input',
+              'input_file',
+              type=str,
+              help='Only create data for imas handles in this data.csv file.')
 @common_options(*logging_options, yes_option, dry_run_option)
 def cli_create(**kwargs):
     """Create data sets for large scale validation.

--- a/src/duqtools/large_scale_validation/cli.py
+++ b/src/duqtools/large_scale_validation/cli.py
@@ -111,6 +111,14 @@ def cli_create(**kwargs):
     type=str,
     help=
     'Only submit jobs for runs in subdirectories matching this glob pattern.')
+@click.option(
+    '-i',
+    '--input',
+    'input_file',
+    type=str,
+    help=
+    'Only submit jobs for configs where `template_data` matches a handle in this data.csv.'
+)
 @click.option('-a', '--array', is_flag=True, help='Submit jobs as array.')
 @common_options(*logging_options, yes_option, dry_run_option)
 def cli_submit(**kwargs):

--- a/src/duqtools/large_scale_validation/cli.py
+++ b/src/duqtools/large_scale_validation/cli.py
@@ -67,11 +67,14 @@ def cli_setup(**kwargs):
     help=
     'Only create data for configs in subdirectories matching this glob pattern.'
 )
-@click.option('-i',
-              '--input',
-              'input_file',
-              type=str,
-              help='Only create data for imas handles in this data.csv file.')
+@click.option(
+    '-i',
+    '--input',
+    'input_file',
+    type=str,
+    help=
+    'Only create data for configs where `template_data` matches a handle in this data.csv.'
+)
 @common_options(*logging_options, yes_option, dry_run_option)
 def cli_create(**kwargs):
     """Create data sets for large scale validation.

--- a/src/duqtools/large_scale_validation/cli.py
+++ b/src/duqtools/large_scale_validation/cli.py
@@ -60,9 +60,20 @@ def cli_setup(**kwargs):
 @click.option('--force',
               is_flag=True,
               help='Overwrite existing run directories and IDS data.')
+@click.option(
+    '-p',
+    '--pattern',
+    type=str,
+    help=
+    'Only create data for configs in subdirectories matching this glob pattern.'
+)
 @common_options(*logging_options, yes_option, dry_run_option)
 def cli_create(**kwargs):
-    """Create data sets for large scale validation."""
+    """Create data sets for large scale validation.
+
+    Example to only match config files in subdirectories matching jet*:
+    `duqduq create --pattern 'jet*/**'`
+    """
     from .create import create
     with op_queue_context():
         create(**kwargs)

--- a/src/duqtools/large_scale_validation/cli.py
+++ b/src/duqtools/large_scale_validation/cli.py
@@ -97,6 +97,12 @@ def cli_create(**kwargs):
               type=str,
               multiple=True,
               help='Only submit jobs with this status.')
+@click.option(
+    '-p',
+    '--pattern',
+    type=str,
+    help=
+    'Only submit jobs for runs in subdirectories matching this glob pattern.')
 @click.option('-a', '--array', is_flag=True, help='Submit jobs as array.')
 @common_options(*logging_options, yes_option, dry_run_option)
 def cli_submit(**kwargs):

--- a/src/duqtools/large_scale_validation/create.py
+++ b/src/duqtools/large_scale_validation/create.py
@@ -5,7 +5,14 @@ from ..create import create as duqtools_create
 from ..utils import work_directory
 
 
-def create(*, pattern='**', **kwargs):
+def create(*, pattern: str = '**', **kwargs):
+    """Create runs for large scale validation.
+
+    Parameters
+    ----------
+    pattern : str
+        Find runs.yaml files only in subdirectories matching this glob pattern
+    """
     cwd = Path.cwd()
 
     config_files = cwd.glob(f'{pattern}/duqtools.yaml')

--- a/src/duqtools/large_scale_validation/create.py
+++ b/src/duqtools/large_scale_validation/create.py
@@ -5,10 +5,10 @@ from ..create import create as duqtools_create
 from ..utils import work_directory
 
 
-def create(**kwargs):
+def create(*, pattern='**', **kwargs):
     cwd = Path.cwd()
 
-    config_files = cwd.glob('**/duqtools.yaml')
+    config_files = cwd.glob(f'{pattern}/duqtools.yaml')
 
     for config_file in config_files:
         cfg.parse_file(config_file)

--- a/src/duqtools/large_scale_validation/create.py
+++ b/src/duqtools/large_scale_validation/create.py
@@ -18,8 +18,9 @@ def create(*, input_file: str, pattern: str, **kwargs):
     if pattern is None:
         pattern = '**'
 
-    handles = read_imas_handles_from_file(
-        input_file).values() if input_file else None
+    handles = None
+    if input_file:
+        handles = read_imas_handles_from_file(input_file).values()
 
     cwd = Path.cwd()
 

--- a/src/duqtools/large_scale_validation/create.py
+++ b/src/duqtools/large_scale_validation/create.py
@@ -5,7 +5,7 @@ from ..create import create as duqtools_create
 from ..utils import work_directory
 
 
-def create(*, pattern: str = '**', **kwargs):
+def create(*, input_file: str, pattern: str = '**', **kwargs):
     """Create runs for large scale validation.
 
     Parameters
@@ -16,6 +16,10 @@ def create(*, pattern: str = '**', **kwargs):
     cwd = Path.cwd()
 
     config_files = cwd.glob(f'{pattern}/duqtools.yaml')
+
+    breakpoint()
+    ## Load list of imas handles
+    ## match run.data_in to list of imas handles
 
     for config_file in config_files:
         cfg.parse_file(config_file)

--- a/src/duqtools/large_scale_validation/create.py
+++ b/src/duqtools/large_scale_validation/create.py
@@ -2,27 +2,34 @@ from pathlib import Path
 
 from ..config import cfg
 from ..create import create as duqtools_create
-from ..utils import work_directory
+from ..utils import read_imas_handles_from_file, work_directory
 
 
-def create(*, input_file: str, pattern: str = '**', **kwargs):
+def create(*, input_file: str, pattern: str, **kwargs):
     """Create runs for large scale validation.
 
     Parameters
     ----------
+    input_file : str
+        Only create for configs where template_data matches a handle in the data.csv
     pattern : str
         Find runs.yaml files only in subdirectories matching this glob pattern
     """
+    if pattern is None:
+        pattern = '**'
+
+    handles = read_imas_handles_from_file(
+        input_file).values() if input_file else None
+
     cwd = Path.cwd()
 
     config_files = cwd.glob(f'{pattern}/duqtools.yaml')
 
-    breakpoint()
-    ## Load list of imas handles
-    ## match run.data_in to list of imas handles
-
     for config_file in config_files:
         cfg.parse_file(config_file)
+
+        if handles and (cfg.create.template_data not in handles):
+            continue
 
         config_dir = config_file.parent
 

--- a/src/duqtools/large_scale_validation/submit.py
+++ b/src/duqtools/large_scale_validation/submit.py
@@ -12,16 +12,11 @@ from ..submit import (
     lockfile_ok,
     status_file_ok,
 )
+from ..utils import read_imas_handles_from_file
 
 
-def submit(*,
-           array,
-           force,
-           max_jobs,
-           schedule,
-           status_filter: Sequence[str],
-           pattern: str = '**',
-           **kwargs):
+def submit(*, array, force, max_jobs, schedule, input_file: str, pattern: str,
+           status_filter: Sequence[str], **kwargs):
     """Submit nested duqtools configs.
 
     Parameters
@@ -33,11 +28,20 @@ def submit(*,
     schedule : bool
         Schedule `max_jobs` to run at once, keeps the process alive until
         finished.
-    status_filter : list[str]
-        Only submit jobs with this status.
+    input_file : str
+        Only submit jobs for configs where template_data matches a handle in the data.csv
     pattern : str
         Find runs.yaml files only in subdirectories matching this glob pattern
+    status_filter : list[str]
+        Only submit jobs with this status.
     """
+    if pattern is None:
+        pattern = '**'
+
+    handles = None
+    if input_file:
+        handles = read_imas_handles_from_file(input_file).values()
+
     cwd = Path.cwd()
 
     dirs = [file.parent for file in cwd.glob(f'{pattern}/runs.yaml')]
@@ -47,6 +51,9 @@ def submit(*,
     for dir in dirs:
         config_file = dir / 'duqtools.yaml'
         cfg.parse_file(config_file)
+
+        if handles and (cfg.create.template_data not in handles):
+            continue
 
         if not cfg.submit:
             raise SubmitError(

--- a/src/duqtools/large_scale_validation/submit.py
+++ b/src/duqtools/large_scale_validation/submit.py
@@ -14,7 +14,13 @@ from ..submit import (
 )
 
 
-def submit(*, array, force, max_jobs, schedule, status_filter: Sequence[str],
+def submit(*,
+           array,
+           force,
+           max_jobs,
+           schedule,
+           status_filter: Sequence[str],
+           pattern: str = '**',
            **kwargs):
     """Submit nested duqtools configs.
 
@@ -29,10 +35,12 @@ def submit(*, array, force, max_jobs, schedule, status_filter: Sequence[str],
         finished.
     status_filter : list[str]
         Only submit jobs with this status.
+    pattern : str
+        Find runs.yaml files only in subdirectories matching this glob pattern
     """
     cwd = Path.cwd()
 
-    dirs = [file.parent for file in cwd.glob('**/runs.yaml')]
+    dirs = [file.parent for file in cwd.glob(f'{pattern}/runs.yaml')]
 
     jobs: list[Job] = []
 


### PR DESCRIPTION
This PR adds some filtering for imas data and config directories for `duqduq create` and `duqduq submit`.

### Todo

- [x] create, path filter
- [x] create, imas filter (data.csv)
- [x] submit, path filter
- [x] submit, imas filter (data.csv)

Closes #573