### PR TITLE
Generate base run only

### DIFF
--- a/src/duqtools/cli.py
+++ b/src/duqtools/cli.py
@@ -273,6 +273,9 @@ def cli_setup(**kwargs):
 @click.option('--force',
               is_flag=True,
               help='Overwrite existing run directories and IDS data.')
+@click.option('--base',
+              is_flag=True,
+              help='Create base run (ignores `dimensions`/`sampler`).')
 @common_options(*all_options)
 def cli_create(**kwargs):
     """Create the UQ run files."""

--- a/src/duqtools/create.py
+++ b/src/duqtools/create.py
@@ -222,7 +222,12 @@ class CreateManager:
                                           out=model.data_out)
 
 
-def create(*, force, config, absolute_dirpath: bool = False, **kwargs):
+def create(*,
+           force,
+           config,
+           base: bool,
+           absolute_dirpath: bool = False,
+           **kwargs):
     """Create input for jetto and IDS data structures.
 
     Parameters
@@ -231,6 +236,8 @@ def create(*, force, config, absolute_dirpath: bool = False, **kwargs):
         Override protection if data and directories already exist.
     config : Path
         Config file location
+    base : bool
+        If true, create base run by ignoring `sampler`/`dimensions`.
 
     **kwargs
         Unused.

--- a/src/duqtools/large_scale_validation/cli.py
+++ b/src/duqtools/large_scale_validation/cli.py
@@ -75,6 +75,9 @@ def cli_setup(**kwargs):
     help=
     'Only create data for configs where `template_data` matches a handle in this data.csv.'
 )
+@click.option('--base',
+              is_flag=True,
+              help='Create base runs (ignores `dimensions`/`sampler`).')
 @common_options(*logging_options, yes_option, dry_run_option)
 def cli_create(**kwargs):
     """Create data sets for large scale validation.

--- a/src/duqtools/large_scale_validation/create.py
+++ b/src/duqtools/large_scale_validation/create.py
@@ -5,11 +5,13 @@ from ..create import create as duqtools_create
 from ..utils import read_imas_handles_from_file, work_directory
 
 
-def create(*, input_file: str, pattern: str, **kwargs):
+def create(*, base: bool, input_file: str, pattern: str, **kwargs):
     """Create runs for large scale validation.
 
     Parameters
     ----------
+    base : bool
+        If true, create base runs by ignoring `sampler`/`dimensions`.
     input_file : str
         Only create for configs where template_data matches a handle in the data.csv
     pattern : str
@@ -37,4 +39,5 @@ def create(*, input_file: str, pattern: str, **kwargs):
         with work_directory(config_dir):
             duqtools_create(config=config_file,
                             absolute_dirpath=True,
+                            base=base,
                             **kwargs)

--- a/src/duqtools/matrix_samplers.py
+++ b/src/duqtools/matrix_samplers.py
@@ -1,10 +1,10 @@
 import itertools
-from typing import Optional
+from typing import Any, Optional
 
 from scipy.stats import qmc
 
 
-def cartesian_product(*iterables, **kwargs):
+def cartesian_product(*iterables, **kwargs) -> list[Any]:
     """Return cartesian product of input iterables.
 
     Uses `itertools.product`
@@ -22,7 +22,7 @@ def cartesian_product(*iterables, **kwargs):
     return list(itertools.product(*iterables))
 
 
-def _sampler(func, *iterables, n_samples: int, **kwargs):
+def _sampler(func, *iterables, n_samples: int, **kwargs) -> list[Any]:
     """Generic sampler."""
     bounds = tuple(len(iterable) for iterable in iterables)
 
@@ -39,7 +39,7 @@ def _sampler(func, *iterables, n_samples: int, **kwargs):
 def latin_hypercube(*iterables,
                     n_samples: int,
                     seed: Optional[int] = None,
-                    **kwargs):
+                    **kwargs) -> list[Any]:
     """Sample input iterables using Latin hypercube sampling (LHS).
 
     Uses `scipy.stats.qmc.LatinHyperCube`.
@@ -64,7 +64,10 @@ def latin_hypercube(*iterables,
                     seed=seed)
 
 
-def sobol(*iterables, n_samples: int, seed: Optional[int] = None, **kwargs):
+def sobol(*iterables,
+          n_samples: int,
+          seed: Optional[int] = None,
+          **kwargs) -> list[Any]:
     """Sample input iterables using the Sobol sampling method for generating
     low discrepancy sequences.
 
@@ -89,7 +92,10 @@ def sobol(*iterables, n_samples: int, seed: Optional[int] = None, **kwargs):
     return _sampler(qmc.Sobol, *iterables, n_samples=n_samples, seed=seed)
 
 
-def halton(*iterables, n_samples: int, seed: Optional[int] = None, **kwargs):
+def halton(*iterables,
+           n_samples: int,
+           seed: Optional[int] = None,
+           **kwargs) -> list[Any]:
     """Sample input iterables using the Halton sampling method.
 
     Uses `scipy.stats.qmc.Halton`.


### PR DESCRIPTION
This PR adds the functionality for `duqtools create --base` and `duqduq create --base` to just generate the base run. This will ignore anything specified in `dimensions`/`sampler`.

Addresses #565 