### PR TITLE
Revise config loading

### DIFF
--- a/src/duqtools/cli.py
+++ b/src/duqtools/cli.py
@@ -10,7 +10,7 @@ from pydantic import ValidationError
 
 from ._click_opt_groups import GroupCmd, GroupOpt
 from ._logging_utils import TermEscapeCodeFormatter, duqlog_screen
-from .config import cfg
+from .config import cfg, load_config
 from .operations import op_queue, op_queue_context
 
 logger = logging.getLogger(__name__)
@@ -169,7 +169,7 @@ class OptionParser:
 
     def parse_config(self, *, config, **kwargs):
         try:
-            cfg.parse_file(config)
+            load_config(config)
         except ValidationError as e:
             exit(e)
 
@@ -279,9 +279,9 @@ def cli_setup(**kwargs):
 @common_options(*all_options)
 def cli_create(**kwargs):
     """Create the UQ run files."""
-    from .create import create
+    from .create import create_entry
     with op_queue_context():
-        create(**kwargs)
+        create_entry(**kwargs)
 
 
 @cli.command('recreate', cls=GroupCmd)

--- a/src/duqtools/config/__init__.py
+++ b/src/duqtools/config/__init__.py
@@ -1,9 +1,10 @@
-from ._config import Config, cfg
+from ._config import Config, cfg, load_config
 from ._variables import lookup_vars, var_lookup
 
 __all__ = [
     'cfg',
     'Config',
+    'load_config',
     'lookup_vars',
     'var_lookup',
 ]

--- a/src/duqtools/config/_config.py
+++ b/src/duqtools/config/_config.py
@@ -30,9 +30,10 @@ def load_config(path: Union[str, Path]) -> Config:
     if new_cfg.extra_variables:
         var_lookup.update(new_cfg.extra_variables.to_variable_dict())
 
-    new_cfg._path = path
-
     cfg.__dict__.update(new_cfg.__dict__)
+
+    for obj in (cfg, new_cfg):
+        obj._path = path
 
     return new_cfg
 

--- a/src/duqtools/config/_config.py
+++ b/src/duqtools/config/_config.py
@@ -1,32 +1,40 @@
+"""Config class containing all configs, can be used with:
+
+    from duqtools.config import cfg
+    cfg.<variable you want>
+
+To update the config:
+
+    load_config('duqtools.yaml')
+"""
+
 from __future__ import annotations
+
+from pathlib import Path
+from typing import Union
 
 from ..schema.cli import ConfigModel
 
 
 class Config(ConfigModel):
-    """Config class containing all configs, can be used with:
+    ...
 
-        from duqtools.config import cfg
-        cfg.<variable you want>
 
-    To update the config:
+def load_config(path: Union[str, Path]) -> Config:
+    global cfg
 
-        cfg.parse_file('duqtools.yaml')
-    """
-    _instance = None
+    new_cfg = Config.parse_file(path)
 
-    def __new__(cls, *args, **kwargs):
-        # Make it a singleton
-        if not Config._instance:
-            Config._instance = object.__new__(cls)
-        return Config._instance
+    from ._variables import var_lookup
 
-    def parse_file(self, *args, **kwargs):
-        """Add extra variables to variable lookup table."""
-        super().parse_file(*args, **kwargs)
-        from ._variables import var_lookup
-        if self.extra_variables:
-            var_lookup.update(self.extra_variables.to_variable_dict())
+    if new_cfg.extra_variables:
+        var_lookup.update(new_cfg.extra_variables.to_variable_dict())
+
+    new_cfg._path = path
+
+    cfg.__dict__.update(new_cfg.__dict__)
+
+    return new_cfg
 
 
 cfg = Config.construct()

--- a/src/duqtools/create.py
+++ b/src/duqtools/create.py
@@ -2,7 +2,7 @@ import logging
 import shutil
 import warnings
 from pathlib import Path
-from typing import Any, Sequence, Union
+from typing import Any, Sequence
 
 import pandas as pd
 
@@ -276,9 +276,9 @@ def create(*,
     create_mgr.copy_config()
 
 
-def create_entry(config_file: Union[str, Path], *args, **kwargs):
+def create_entry(*args, **kwargs):
     """Entry point for duqtools cli."""
-    from ..config import cfg
+    from .config import cfg
     return create(cfg=cfg, *args, **kwargs)
 
 

--- a/src/duqtools/large_scale_validation/create.py
+++ b/src/duqtools/large_scale_validation/create.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from ..config import load_config
-from ..create import create as duqtools_create
+from ..create import create as create_entry
 from ..utils import read_imas_handles_from_file, work_directory
 
 
@@ -39,7 +39,7 @@ def create(*, no_sampling: bool, input_file: str, pattern: str, **kwargs):
         config_dir = config_file.parent
 
         with work_directory(config_dir):
-            duqtools_create(cfg=cfg,
-                            absolute_dirpath=True,
-                            no_sampling=no_sampling,
-                            **kwargs)
+            create_entry(cfg=cfg,
+                         absolute_dirpath=True,
+                         no_sampling=no_sampling,
+                         **kwargs)

--- a/src/duqtools/large_scale_validation/create.py
+++ b/src/duqtools/large_scale_validation/create.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from ..config import cfg
+from ..config import load_config
 from ..create import create as duqtools_create
 from ..utils import read_imas_handles_from_file, work_directory
 
@@ -29,7 +29,9 @@ def create(*, no_sampling: bool, input_file: str, pattern: str, **kwargs):
     config_files = cwd.glob(f'{pattern}/duqtools.yaml')
 
     for config_file in config_files:
-        cfg.parse_file(config_file)
+        cfg = load_config(config_file)
+
+        assert cfg.create
 
         if handles and (cfg.create.template_data not in handles):
             continue
@@ -37,7 +39,7 @@ def create(*, no_sampling: bool, input_file: str, pattern: str, **kwargs):
         config_dir = config_file.parent
 
         with work_directory(config_dir):
-            duqtools_create(config=config_file,
+            duqtools_create(cfg=cfg,
                             absolute_dirpath=True,
                             no_sampling=no_sampling,
                             **kwargs)

--- a/src/duqtools/large_scale_validation/merge.py
+++ b/src/duqtools/large_scale_validation/merge.py
@@ -6,7 +6,7 @@ import pandas as pd
 
 from duqtools.api import ImasHandle
 
-from ..config import cfg
+from ..config import load_config
 from ..merge import _merge, _resolve_variables
 from ..models import Job, Locations
 from ..operations import add_to_op_queue, op_queue
@@ -33,7 +33,10 @@ def merge(force: bool, var_names: Sequence[str], **kwargs):
     for config_file in config_files:
         run_name = config_file.parent.name
 
-        cfg.parse_file(config_file)
+        cfg = load_config(config_file)
+
+        assert cfg.create
+        assert cfg.create.runs_dir
 
         config_dir = config_file.parent
 

--- a/src/duqtools/large_scale_validation/status.py
+++ b/src/duqtools/large_scale_validation/status.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import click
 
-from ..config import cfg
+from ..config import load_config
 from ..models import Job, Locations
 from ..status import Status, StatusError
 
@@ -32,7 +32,7 @@ def status(*, progress: bool, detailed: bool, pattern: str, **kwargs):
     click.echo()
 
     for config_file in config_files:
-        cfg.parse_file(config_file)
+        cfg = load_config(config_file)
 
         if not cfg.status:
             raise StatusError(

--- a/src/duqtools/large_scale_validation/submit.py
+++ b/src/duqtools/large_scale_validation/submit.py
@@ -2,10 +2,9 @@ from collections import deque
 from pathlib import Path
 from typing import Deque, Sequence
 
-from ..config import cfg
+from ..config import load_config
 from ..models import Job, Locations
 from ..submit import (
-    SubmitError,
     job_array_submitter,
     job_scheduler,
     job_submitter,
@@ -53,14 +52,13 @@ def submit(*, array, force, max_jobs, schedule, max_array_size: int,
 
     for drc in dirs:
         config_file = drc / 'duqtools.yaml'
-        cfg.parse_file(config_file)
+        cfg = load_config(config_file)
+
+        assert cfg.create
+        assert cfg.submit
 
         if handles and (cfg.create.template_data not in handles):
             continue
-
-        if not cfg.submit:
-            raise SubmitError(
-                f'Submit field required in config file: {config_file}')
 
         config_dir = config_file.parent
 

--- a/src/duqtools/list_variables.py
+++ b/src/duqtools/list_variables.py
@@ -1,7 +1,7 @@
 import click
 from pydantic import ValidationError
 
-from duqtools.config import cfg, var_lookup
+from duqtools.config import load_config, var_lookup
 
 cs = click.style
 
@@ -38,7 +38,7 @@ def list_variables(*, config, **kwargs):
         Unused.
     """
     try:
-        cfg.parse_file(config)
+        cfg = load_config(config)
     except FileNotFoundError:
         print(f'Could not find: {config}')
     except ValidationError as e:

--- a/src/duqtools/schema/cli.py
+++ b/src/duqtools/schema/cli.py
@@ -197,4 +197,4 @@ class ConfigModel(BaseModel):
         description=
         'If true, do not output to stdout, except for mandatory prompts.')
 
-    _path: Union[Path, str] = PrivateAttr()
+    _path: Union[Path, str] = PrivateAttr(None)

--- a/src/duqtools/schema/cli.py
+++ b/src/duqtools/schema/cli.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import Literal, Optional, Union
 
-from pydantic import DirectoryPath, Field
+from pydantic import DirectoryPath, Field, PrivateAttr
 
 from ._basemodel import BaseModel
 from ._description_helpers import formatter as f
@@ -196,3 +196,5 @@ class ConfigModel(BaseModel):
         False,
         description=
         'If true, do not output to stdout, except for mandatory prompts.')
+
+    _path: Union[Path, str] = PrivateAttr()


### PR DESCRIPTION
This PR revises how the config is created. Currently we are instantiating the config as a global singleton. This works as long as code is run 'in sequence' or a single config is used. For duqduq we loop through different configs. This gives issues when operations are added to the queue, code that relies on the global config would always point to the latest config that was loaded.

The config being a singleton makes it tricky to make a copy of the model and pass that.

This PR gets rid of the singleton and adds a function `load_config` to load a new instance of the duqtools config. This makes it easier to load the config from a path and pass it around by reference. 

The global config is updated in `load_config` with the new keys for compatibility with all functions that rely on it.

Closes #517
