### PR TITLE
Add python api for duqtools create and submit

### DIFF
--- a/docs/examples/create_api.ipynb
+++ b/docs/examples/create_api.ipynb
@@ -1,0 +1,186 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "a59fd9a4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "0dd5b45b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[33m16:28:26 [WARNING] Python module 'omas' not found. Submodule 'jams' needs it @jams.py:14\u001b[0m\n",
+      "\u001b[33m16:28:26 [WARNING] Python module 'netCDF4' not found. Submodule 'transp' needs it @transp.py:25\u001b[0m\n",
+      "Source data: g2aho/aug/36982/2\n",
+      "- \u001b[32mCreating run\u001b[0m : /afs/eufus.eu/user/g/g2ssmee/jetto_runs/duqduq/data_123/run_0000\n",
+      "- \u001b[32mCopy ids from template to\u001b[0m : /gss_efgw_work/work/g2ssmee/jetto/runs/duqduq/data_123/run_0000/imasdb/aug/36982/1\n",
+      "- \u001b[32mCopying template to\u001b[0m : /afs/eufus.eu/user/g/g2ssmee/jetto_runs/duqduq/data_123/run_0000\n",
+      "- \u001b[32mSetting inital condition of\u001b[0m : /gss_efgw_work/work/g2ssmee/jetto/runs/duqduq/data_123/run_0000/imasdb/aug/36982/1\n",
+      "- \u001b[32mWriting new batchfile\u001b[0m : run_0000\n",
+      "- \u001b[32mUpdating imas locations of\u001b[0m : /afs/eufus.eu/user/g/g2ssmee/jetto_runs/duqduq/data_123/run_0000\n",
+      "- \u001b[32mWriting runs\u001b[0m : /afs/eufus.eu/g2itmuse/user/g2ssmee/duqtools/docs/examples/runs.yaml\n",
+      "- \u001b[32mWriting csv\u001b[0m\n",
+      "- \u001b[32mCopying config to run directory\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "from duqtools.api import create\n",
+    "\n",
+    "import logging\n",
+    "\n",
+    "logging.basicConfig(\n",
+    "    level=logging.INFO,\n",
+    "    format='%(message)s',\n",
+    ")\n",
+    "\n",
+    "config = {\n",
+    "    'tag': 'data_01',\n",
+    "    'create': {\n",
+    "        'runs_dir': '/afs/eufus.eu/user/g/g2ssmee/jetto_runs/duqduq/data_123',\n",
+    "        'template': '/afs/eufus.eu/user/g/g2ssmee/jetto_runs/interpretive_esco02',\n",
+    "        'template_data': {\n",
+    "            'user': 'g2aho',\n",
+    "            'db': 'aug',\n",
+    "            'shot': 36982,\n",
+    "            'run': 2,\n",
+    "        },\n",
+    "        'operations': [\n",
+    "            {\n",
+    "                'variable': 'major_radius',\n",
+    "                'operator': 'copyto',\n",
+    "                'value': 165.0,\n",
+    "            },\n",
+    "            {\n",
+    "                'variable': 'b_field',\n",
+    "                'operator': 'copyto',\n",
+    "                'value': -2.5725,\n",
+    "            },\n",
+    "            {\n",
+    "                'variable': 't_start',\n",
+    "                'operator': 'copyto',\n",
+    "                'value': 2.875,\n",
+    "            },\n",
+    "            {\n",
+    "                'variable': 't_end',\n",
+    "                'operator': 'copyto',\n",
+    "                'value': 2.885,\n",
+    "            },\n",
+    "        ],\n",
+    "    },\n",
+    "    'system': 'jetto',\n",
+    "}\n",
+    "\n",
+    "job = create(config, force=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "ebf18af8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "submitting script via slurm ['sbatch', '/gss_efgw_work/work/g2ssmee/jetto/runs/duqduq/data_123/run_0000/.llcmd']\n",
+      "submission returned: b'Submitted batch job 235270\\n'\n"
+     ]
+    }
+   ],
+   "source": [
+    "job.submit()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "770879bc",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      0.00 - no status\n",
+      "      1.00 - no status\n",
+      "      2.00 - no status\n",
+      "      3.01 - no status\n",
+      "      4.01 - no status\n",
+      "      5.01 - no status\n",
+      "      6.02 - no status\n",
+      "      7.02 - no status\n",
+      "      8.02 - no status\n",
+      "      9.02 - no status\n",
+      "     10.11 - no status\n",
+      "     11.23 - no status\n",
+      "     12.38 - running\n",
+      "     13.39 - running\n",
+      "     14.39 - running\n",
+      "     15.39 - running\n",
+      "     16.39 - running\n",
+      "     17.39 - running\n",
+      "     18.40 - running\n",
+      "     19.40 - running\n",
+      "     20.40 - running\n",
+      "     21.40 - running\n",
+      "     22.40 - running\n",
+      "     23.40 - running\n",
+      "     24.40 - running\n",
+      "     25.41 - running\n",
+      "     26.41 - running\n",
+      "     27.41 - running\n",
+      "     28.41 - running\n",
+      "JobStatus.COMPLETED\n"
+     ]
+    }
+   ],
+   "source": [
+    "import time\n",
+    "\n",
+    "t0 = time.time()\n",
+    "\n",
+    "while not job.status() in ('failed', 'completed'):\n",
+    "    t1 = time.time() - t0\n",
+    "    print(f'{t1:10.2f} - {job.status()}')\n",
+    "    time.sleep(1)\n",
+    "\n",
+    "print(job.status())"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": ".venv"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/examples/create_api.ipynb
+++ b/docs/examples/create_api.ipynb
@@ -1,14 +1,43 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "id": "2ae3284c",
+   "metadata": {},
+   "source": [
+    "# Python API\n",
+    "\n",
+    "This notebook demonstrates how to set up a Jetto interpretive simulation and run it via duqtools."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "a59fd9a4",
+   "id": "551ccbc0",
    "metadata": {},
    "outputs": [],
    "source": [
-    "%load_ext autoreload\n",
-    "%autoreload 2"
+    "import logging\n",
+    "\n",
+    "logging.basicConfig(\n",
+    "    level=logging.INFO,\n",
+    "    format='%(message)s',\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4fdf35e7",
+   "metadata": {},
+   "source": [
+    "Below is an example duqtools config.\n",
+    "\n",
+    "The example below takes `t_e` (electron temperature) from the template, and multiplies it by 1.1.\n",
+    "\n",
+    "It also sets a few machine specific parameters (`major_radius`, `b_field`), and adjusts the start (`t_start`) and end time (`t_end`) for the simulation.\n",
+    "\n",
+    "For more documentation on the parameters, check out the documentation here:\n",
+    "https://duqtools.readthedocs.io/en/latest/config/create/"
    ]
   },
   {
@@ -21,36 +50,23 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[33m16:28:26 [WARNING] Python module 'omas' not found. Submodule 'jams' needs it @jams.py:14\u001b[0m\n",
-      "\u001b[33m16:28:26 [WARNING] Python module 'netCDF4' not found. Submodule 'transp' needs it @transp.py:25\u001b[0m\n",
-      "Source data: g2aho/aug/36982/2\n",
-      "- \u001b[32mCreating run\u001b[0m : /afs/eufus.eu/user/g/g2ssmee/jetto_runs/duqduq/data_123/run_0000\n",
-      "- \u001b[32mCopy ids from template to\u001b[0m : /gss_efgw_work/work/g2ssmee/jetto/runs/duqduq/data_123/run_0000/imasdb/aug/36982/1\n",
-      "- \u001b[32mCopying template to\u001b[0m : /afs/eufus.eu/user/g/g2ssmee/jetto_runs/duqduq/data_123/run_0000\n",
-      "- \u001b[32mSetting inital condition of\u001b[0m : /gss_efgw_work/work/g2ssmee/jetto/runs/duqduq/data_123/run_0000/imasdb/aug/36982/1\n",
-      "- \u001b[32mWriting new batchfile\u001b[0m : run_0000\n",
-      "- \u001b[32mUpdating imas locations of\u001b[0m : /afs/eufus.eu/user/g/g2ssmee/jetto_runs/duqduq/data_123/run_0000\n",
-      "- \u001b[32mWriting runs\u001b[0m : /afs/eufus.eu/g2itmuse/user/g2ssmee/duqtools/docs/examples/runs.yaml\n",
-      "- \u001b[32mWriting csv\u001b[0m\n",
-      "- \u001b[32mCopying config to run directory\u001b[0m\n"
+      "\u001b[33m16:33:05 [WARNING] Python module 'omas' not found. Submodule 'jams' needs it @jams.py:14\u001b[0m\n",
+      "Python module 'omas' not found. Submodule 'jams' needs it\n",
+      "\u001b[33m16:33:05 [WARNING] Python module 'netCDF4' not found. Submodule 'transp' needs it @transp.py:25\u001b[0m\n",
+      "Python module 'netCDF4' not found. Submodule 'transp' needs it\n"
      ]
     }
    ],
    "source": [
     "from duqtools.api import create\n",
     "\n",
-    "import logging\n",
-    "\n",
-    "logging.basicConfig(\n",
-    "    level=logging.INFO,\n",
-    "    format='%(message)s',\n",
-    ")\n",
-    "\n",
     "config = {\n",
     "    'tag': 'data_01',\n",
     "    'create': {\n",
-    "        'runs_dir': '/afs/eufus.eu/user/g/g2ssmee/jetto_runs/duqduq/data_123',\n",
-    "        'template': '/afs/eufus.eu/user/g/g2ssmee/jetto_runs/interpretive_esco02',\n",
+    "        'runs_dir':\n",
+    "        '/afs/eufus.eu/user/g/g2ssmee/jetto_runs/duqduq/data_123',\n",
+    "        'template':\n",
+    "        '/afs/eufus.eu/user/g/g2ssmee/jetto_runs/interpretive_esco02',\n",
     "        'template_data': {\n",
     "            'user': 'g2aho',\n",
     "            'db': 'aug',\n",
@@ -58,6 +74,11 @@
     "            'run': 2,\n",
     "        },\n",
     "        'operations': [\n",
+    "            {\n",
+    "                'variable': 't_e',\n",
+    "                'operator': 'multiply',\n",
+    "                'value': 1.1,\n",
+    "            },\n",
     "            {\n",
     "                'variable': 'major_radius',\n",
     "                'operator': 'copyto',\n",
@@ -81,14 +102,167 @@
     "        ],\n",
     "    },\n",
     "    'system': 'jetto',\n",
-    "}\n",
-    "\n",
-    "job = create(config, force=True)"
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0ebabe97",
+   "metadata": {},
+   "source": [
+    "Running `create` will create a new run from the template, copy over the template data, and apply the operations to the data. This will return a `job` and `run` object."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
+   "id": "6fa8ce89",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Source data: g2aho/aug/36982/2\n",
+      "- \u001b[32mCreating run\u001b[0m : /afs/eufus.eu/user/g/g2ssmee/jetto_runs/duqduq/data_123/run_0000\n",
+      "- \u001b[32mCopy ids from template to\u001b[0m : /gss_efgw_work/work/g2ssmee/jetto/runs/duqduq/data_123/run_0000/imasdb/aug/36982/1\n",
+      "- \u001b[32mCopying template to\u001b[0m : /afs/eufus.eu/user/g/g2ssmee/jetto_runs/duqduq/data_123/run_0000\n",
+      "- \u001b[32mSetting inital condition of\u001b[0m : /gss_efgw_work/work/g2ssmee/jetto/runs/duqduq/data_123/run_0000/imasdb/aug/36982/1\n",
+      "Apply operator='multiply' scale_to_error=False variable=IDSVariableModel(ids='core_profiles', path='profiles_1d/*/electrons/temperature', type='IDS-variable', name='t_e', dims=['time', '$rho_tor_norm']) value=1.1\n",
+      "Writing data entry: /gss_efgw_work/work/g2ssmee/jetto/runs/duqduq/data_123/run_0000/imasdb/aug/36982/1\n",
+      "- \u001b[32mWriting new batchfile\u001b[0m : run_0000\n",
+      "- \u001b[32mUpdating imas locations of\u001b[0m : /afs/eufus.eu/user/g/g2ssmee/jetto_runs/duqduq/data_123/run_0000\n",
+      "- \u001b[32mWriting runs\u001b[0m : /afs/eufus.eu/g2itmuse/user/g2ssmee/duqtools/docs/examples/runs.yaml\n",
+      "- \u001b[32mWriting csv\u001b[0m\n"
+     ]
+    }
+   ],
+   "source": [
+    "job, run = create(config)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c167c932",
+   "metadata": {},
+   "source": [
+    "`run` contains some metadata about the run and the locations to the input and output data for the run."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "1b5007a2",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'dirname': PosixPath('/afs/eufus.eu/user/g/g2ssmee/jetto_runs/duqduq/data_123/run_0000'),\n",
+       " 'shortname': PosixPath('run_0000'),\n",
+       " 'data_in': {'relative_location': None,\n",
+       "  'user': '/gss_efgw_work/work/g2ssmee/jetto/runs/duqduq/data_123/run_0000/imasdb',\n",
+       "  'db': 'aug',\n",
+       "  'shot': 36982,\n",
+       "  'run': 1},\n",
+       " 'data_out': {'relative_location': None,\n",
+       "  'user': '/gss_efgw_work/work/g2ssmee/jetto/runs/duqduq/data_123/run_0000/imasdb',\n",
+       "  'db': 'aug',\n",
+       "  'shot': 36982,\n",
+       "  'run': 2},\n",
+       " 'operations': [{'operator': 'multiply',\n",
+       "   'scale_to_error': False,\n",
+       "   'variable': {'ids': 'core_profiles',\n",
+       "    'path': 'profiles_1d/*/electrons/temperature',\n",
+       "    'type': 'IDS-variable',\n",
+       "    'name': 't_e',\n",
+       "    'dims': ['time', '$rho_tor_norm']},\n",
+       "   'value': 1.1},\n",
+       "  {'operator': 'copyto',\n",
+       "   'scale_to_error': False,\n",
+       "   'variable': {'type': 'jetto-variable',\n",
+       "    'name': 'major_radius',\n",
+       "    'lookup': {'doc': 'Reference major radius (R0)',\n",
+       "     'name': 'major_radius',\n",
+       "     'type': 'float',\n",
+       "     'keys': [{'file': 'jetto.jset',\n",
+       "       'field': 'EquilEscoRefPanel.refMajorRadius'},\n",
+       "      {'file': 'jetto.in', 'field': 'RMJ', 'section': 'nlist1'}]}},\n",
+       "   'value': 165.0},\n",
+       "  {'operator': 'copyto',\n",
+       "   'scale_to_error': False,\n",
+       "   'variable': {'type': 'jetto-variable',\n",
+       "    'name': 'b_field',\n",
+       "    'lookup': {'doc': 'B-field (B0)',\n",
+       "     'name': 'b_field',\n",
+       "     'type': 'float',\n",
+       "     'keys': [{'file': 'jetto.jset',\n",
+       "       'field': 'EquilEscoRefPanel.BField.ConstValue'}]}},\n",
+       "   'value': -2.5725},\n",
+       "  {'operator': 'copyto',\n",
+       "   'scale_to_error': False,\n",
+       "   'variable': {'type': 'jetto-variable', 'name': 't_start', 'lookup': None},\n",
+       "   'value': 2.875},\n",
+       "  {'operator': 'copyto',\n",
+       "   'scale_to_error': False,\n",
+       "   'variable': {'type': 'jetto-variable', 'name': 't_end', 'lookup': None},\n",
+       "   'value': 2.885}]}"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "run.dict()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "db0c4c5c",
+   "metadata": {},
+   "source": [
+    "`job` contains information about the status of the job and the locations of the input and output files for the simulation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "f166243d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/gss_efgw_work/work/g2ssmee/jetto/runs/duqduq/data_123/run_0000/jetto.in\n",
+      "True\n",
+      "/gss_efgw_work/work/g2ssmee/jetto/runs/duqduq/data_123/run_0000/jetto.out\n",
+      "False\n",
+      "JobStatus.NOSTATUS\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(job.in_file)\n",
+    "print(job.in_file.exists())\n",
+    "print(job.out_file)\n",
+    "print(job.out_file.exists())\n",
+    "print(job.status())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "74637350",
+   "metadata": {},
+   "source": [
+    "The `job` can be submitted using the configured submit system."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
    "id": "ebf18af8",
    "metadata": {},
    "outputs": [
@@ -97,7 +271,7 @@
      "output_type": "stream",
      "text": [
       "submitting script via slurm ['sbatch', '/gss_efgw_work/work/g2ssmee/jetto/runs/duqduq/data_123/run_0000/.llcmd']\n",
-      "submission returned: b'Submitted batch job 235270\\n'\n"
+      "submission returned: b'Submitted batch job 235793\\n'\n"
      ]
     }
    ],
@@ -106,44 +280,60 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 4,
-   "id": "770879bc",
+   "cell_type": "markdown",
+   "id": "dd1161fc",
    "metadata": {},
+   "source": [
+    "Track the status of the job through `job.status()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "770879bc",
+   "metadata": {
+    "scrolled": false
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "JobStatus.NOSTATUS\n",
       "      0.00 - no status\n",
-      "      1.00 - no status\n",
-      "      2.00 - no status\n",
-      "      3.01 - no status\n",
-      "      4.01 - no status\n",
-      "      5.01 - no status\n",
-      "      6.02 - no status\n",
-      "      7.02 - no status\n",
-      "      8.02 - no status\n",
-      "      9.02 - no status\n",
-      "     10.11 - no status\n",
-      "     11.23 - no status\n",
-      "     12.38 - running\n",
-      "     13.39 - running\n",
-      "     14.39 - running\n",
-      "     15.39 - running\n",
-      "     16.39 - running\n",
-      "     17.39 - running\n",
-      "     18.40 - running\n",
-      "     19.40 - running\n",
-      "     20.40 - running\n",
-      "     21.40 - running\n",
-      "     22.40 - running\n",
-      "     23.40 - running\n",
-      "     24.40 - running\n",
-      "     25.41 - running\n",
-      "     26.41 - running\n",
-      "     27.41 - running\n",
-      "     28.41 - running\n",
+      "      1.06 - no status\n",
+      "      2.06 - no status\n",
+      "      3.06 - no status\n",
+      "      4.06 - no status\n",
+      "      5.06 - no status\n",
+      "      6.06 - no status\n",
+      "      7.07 - no status\n",
+      "      8.17 - no status\n",
+      "      9.68 - no status\n",
+      "     10.83 - no status\n",
+      "     12.14 - running\n",
+      "     13.14 - running\n",
+      "     14.14 - running\n",
+      "     15.14 - running\n",
+      "     16.14 - running\n",
+      "     17.14 - running\n",
+      "     18.14 - running\n",
+      "     19.15 - running\n",
+      "     20.15 - running\n",
+      "     21.15 - running\n",
+      "     22.15 - running\n",
+      "     23.15 - running\n",
+      "     24.15 - running\n",
+      "     25.15 - running\n",
+      "     26.16 - running\n",
+      "     27.16 - running\n",
+      "     28.16 - running\n",
+      "     29.16 - running\n",
+      "     30.16 - running\n",
+      "     31.16 - running\n",
+      "     32.17 - running\n",
+      "     33.17 - running\n",
+      "     34.17 - running\n",
       "JobStatus.COMPLETED\n"
      ]
     }
@@ -151,14 +341,88 @@
    "source": [
     "import time\n",
     "\n",
+    "print(job.status())\n",
+    "\n",
     "t0 = time.time()\n",
     "\n",
-    "while not job.status() in ('failed', 'completed'):\n",
+    "while not job.is_done:\n",
     "    t1 = time.time() - t0\n",
     "    print(f'{t1:10.2f} - {job.status()}')\n",
     "    time.sleep(1)\n",
     "\n",
     "print(job.status())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "63d57416",
+   "metadata": {},
+   "source": [
+    "Check that the run has created some data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "e31d53ed",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "run.data_out.exists()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c2e6d609",
+   "metadata": {},
+   "source": [
+    "Load the data into an `xarray.Dataset` and do things with it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "d45faadc",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.collections.PathCollection at 0x2aefd2f4b640>"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkQAAAGxCAYAAACDV6ltAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAA9hAAAPYQGoP6dpAAA1rklEQVR4nO3de3jU5Zn/8c8kMCEBJsghpwUEoZwEREBhRLS0WdMarQqssFKkCrpg0AUUEU+otZKiVtHlUGU17q6Iuhe4lXAoEgMLiUgj2XK2YjT4IwkgJoMYEki+vz/ojJlkkkzCnL/v13XNdZnvPDPzzHetc+/93PfzWAzDMAQAAGBiUcGeAAAAQLAREAEAANMjIAIAAKZHQAQAAEyPgAgAAJgeAREAADA9AiIAAGB6BEQAAMD02gR7AuGgtrZWx44dU8eOHWWxWII9HQAA4AXDMHT69GmlpKQoKqrpHBABkReOHTumHj16BHsaAACgFY4eParu3bs3OYaAyAsdO3aUdOGG2my2IM8GAAB4w+FwqEePHq7f8aYQEHnBuUxms9kIiAAACDPelLtQVA0AAEyPgAgAAJgeAREAADA9AiIAAGB6BEQAAMD0CIgAAIDpERABAADTIyACAACmR0AEAABMj4AIAACYHgERAAAwPQKiICupqFTekZMqqagM9lQAADAtDncNond3F2vh2r2qNaQoi7R4/BBNuqqnSioqVXTyjHp3ba/k+NhgTxMAgIhHQBQkJRWVrmBIkmoN6dG1+1ReeU6/33ioQZAEAAD8hyWzICk6ecYVDDnVGIYy/x4MST8GSSynAQDgX2SIgqR31/aKssgtKIqSPAZJBV99p84dWEIDAMBfyBAFSXJ8rBaPH6Joi0WSFG2xaMEvByjK4j7OIumBNXt0x+u7NCYzR+/uLg78ZAEAiHBkiIJo0lU9dV2/bvrq5A/q1TVOyfGx6hTXVo+u3acaw1CUJENqsIR2Xb9uZIoAAPAhAqIgS46PdQtu6gZJ356p0uzVe9zG1xiGvjr5AwERAAA+REAUgpxBUklFZYM6o2iLRb26xtGaDwCAD1FDFMI81Rk9N36wtn9+QmMyc6grAgDARyyGYRjNDzM3h8Oh+Ph4VVRUyGazBfzzSyoqXXVGkjQmM6dB1mjHI+PIFAEAUEdLfr9ZMgsDdeuM8o6c9NiaT10RAACtx5JZmHHuX1RXtMWiOGsUZ6IBANBKBERhxlNd0a1Xpui25XnUFAEA0ErUEHkh2DVEnjjriuKsUbpteR41RQAA1NOS328yRGEqOT5W9j5ddKa6ptGaIgAA4B0CojDXWE2RsyMNAAA0j4AozDW2VxHLZQAAeI+2+wjg6Uw0SexmDQCAlwiIIkT9M9He3V2shWv3qtaQoizS4vFDNOmqnkGcIQAAoYslswhUUlHpCoakC2ehPbp2H3sUAQDQCAKiCFR08gydZwAAtAABUQSi8wwAgJYJakD01FNPyWKxuD0GDBjgev7s2bPKyMhQly5d1KFDB02YMEFlZWVu71FcXKz09HTFxcUpISFB8+fP1/nz593G5Obmavjw4YqJiVHfvn2VlZUViK8XNHSeAQDQMkEvqr788sv10Ucfuf5u0+bHKc2dO1fZ2dl6//33FR8fr9mzZ2v8+PHauXOnJKmmpkbp6elKSkpSXl6eSkpKdOedd6pt27Z67rnnJElFRUVKT0/XzJkz9fbbb2vr1q2aMWOGkpOTlZaWFtgvG0CeOs/oOgMAwLOgHt3x1FNP6YMPPlBhYWGD5yoqKtStWzetXr1aEydOlCQdOnRIAwcOVH5+vkaPHq2NGzfqpptu0rFjx5SYmChJWrlypRYsWKATJ07IarVqwYIFys7O1r59+1zvPXnyZJWXl2vTpk1ezTMUj+5oKbrOAABmE1ZHd/ztb39TSkqKLrvsMk2ZMkXFxRcOJi0oKNC5c+eUmprqGjtgwAD17NlT+fn5kqT8/HwNGTLEFQxJUlpamhwOh/bv3+8aU/c9nGOc7+FJVVWVHA6H2yOc0XUGAEDTghoQjRo1SllZWdq0aZNWrFihoqIijR07VqdPn1ZpaamsVqs6derk9prExESVlpZKkkpLS92CIefzzueaGuNwOFRZ6TkgWLx4seLj412PHj16+OLrBg1dZwAANC2oNUS//OUvXf88dOhQjRo1Spdeeqnee+89xcYGr8Zl4cKFmjdvnutvh8MR1kGRs+usblBE1xkAAD8K+pJZXZ06dVK/fv30xRdfKCkpSdXV1SovL3cbU1ZWpqSkJElSUlJSg64z59/NjbHZbI0GXTExMbLZbG6PcEbXGQAATQupgOj777/XkSNHlJycrBEjRqht27baunWr6/nDhw+ruLhYdrtdkmS327V3714dP37cNWbLli2y2WwaNGiQa0zd93COcb6HWUy6qqd2PDJO79wzWjseGUdBNQAAdQS1y+yhhx7SzTffrEsvvVTHjh3TokWLVFhYqAMHDqhbt26aNWuWNmzYoKysLNlsNt1///2SpLy8PEkX2u6HDRumlJQULVmyRKWlpZo6dapmzJjh1nY/ePBgZWRk6O6771ZOTo4eeOABZWdne912HwldZo2hFR8AEKla8vsd1Bqib775Rv/8z/+sb7/9Vt26ddO1116rTz75RN26dZMkvfTSS4qKitKECRNUVVWltLQ0LV++3PX66OhorV+/XrNmzZLdblf79u01bdo0PfPMM64xvXv3VnZ2tubOnaulS5eqe/fuWrVqVUTvQeQtWvEBALggqBmicBGJGaKSikqNycxpUGi945FxZIoAABEhrPYhQnDQig8AwI8IiEyKA2ABAPgRAZFJ0YoPAMCPgn64K4LH0wGwAACYEQGRySXHx7oFQrThAwDMiIAILrThAwDMihoiSLqQGXIGQ9KFc88eXbtPJRWeD8AFACCSEBBBEm34AABzIyCCJNrwAQDmRkAESbThAwDMjaJquNCGDwAwKwIiuKnfhi/Rig8AiHwERGgSrfgAADOghgiNohUfAGAWBERoFK34AACzICBCo2jFBwCYBQERGkUrPgDALCiqRpNoxQcAmAEBEZpVvxWfNnwAQKQhIEKL0IYPAIhE1BDBa7ThAwAiFQERvEYbPgAgUhEQwWu04QMAIhUBEbxGGz4AIFJRVI0WaawNn84zAEA4IyBCi9Vvw6fzDAAQ7lgyw0Wh8wwAEAkIiHBR6DwDAEQCAiJcFDrPAACRgIAIF4XOMwBAJKCoGheNA2ABAOGOgAg+Ub/zTKIVHwAQPgiI4Be04gMAwgk1RPA5WvEBAOGGgAg+Rys+ACDcEBDB52jFBwCEGwIi+Byt+ACAcENRNfzCUys+XWcAgFBFQAS/qduKT9cZACCUsWQGv6PrDAAQ6giI4Hd0nQEAQh0BEfyOrjMAQKgjIILf0XUGAAh1FFUjIBo7AJbOMwBAKCAgQsDUPwCWzjMAQKhgyQxBQecZACCUEBAhKOg8AwCEEgIiBAWdZwCAUEJAhKCg8wwAEEooqkbQcN4ZACBUEBAhqDjvDAAQClgyQ0ig6wwAEEwERAgJdJ0BAIIpZAKizMxMWSwWzZkzx3Xt7NmzysjIUJcuXdShQwdNmDBBZWVlbq8rLi5Wenq64uLilJCQoPnz5+v8+fNuY3JzczV8+HDFxMSob9++ysrKCsA3QkvQdQYACKaQCIh2796tP/7xjxo6dKjb9blz5+rDDz/U+++/r23btunYsWMaP3686/mamhqlp6erurpaeXl5euutt5SVlaUnn3zSNaaoqEjp6ekaN26cCgsLNWfOHM2YMUObN28O2PdD8+g6AwAEk8UwDKP5Yf7z/fffa/jw4Vq+fLmeffZZDRs2TC+//LIqKirUrVs3rV69WhMnTpQkHTp0SAMHDlR+fr5Gjx6tjRs36qabbtKxY8eUmJgoSVq5cqUWLFigEydOyGq1asGCBcrOzta+fftcnzl58mSVl5dr06ZNXs3R4XAoPj5eFRUVstlsvr8JcCmpqOS8MwCAT7Tk9zvoGaKMjAylp6crNTXV7XpBQYHOnTvndn3AgAHq2bOn8vPzJUn5+fkaMmSIKxiSpLS0NDkcDu3fv981pv57p6Wlud7Dk6qqKjkcDrcHAiM5Plb2Pl3cOs/GZObojtd3aUxmjt7dXRzkGQIAIlFQA6I1a9bos88+0+LFixs8V1paKqvVqk6dOrldT0xMVGlpqWtM3WDI+bzzuabGOBwOVVZ67mBavHix4uPjXY8ePXq06vvh4tB5BgAIlKAFREePHtW//uu/6u2331a7du2CNQ2PFi5cqIqKCtfj6NGjwZ6SKdF5BgAIlKAFRAUFBTp+/LiGDx+uNm3aqE2bNtq2bZteeeUVtWnTRomJiaqurlZ5ebnb68rKypSUlCRJSkpKatB15vy7uTE2m02xsZ7rUWJiYmSz2dweCDw6zwAAgRK0gOjnP/+59u7dq8LCQtdj5MiRmjJliuuf27Ztq61bt7pec/jwYRUXF8tut0uS7Ha79u7dq+PHj7vGbNmyRTabTYMGDXKNqfsezjHO90DoaqzzTJLyjpxk6QwA4DNBO7qjY8eOGjx4sNu19u3bq0uXLq7r06dP17x589S5c2fZbDbdf//9stvtGj16tCTphhtu0KBBgzR16lQtWbJEpaWlevzxx5WRkaGYmBhJ0syZM/Vv//Zvevjhh3X33XcrJydH7733nrKzswP7hdEq9c872/75CY3JzOF4DwCATwW9y6wpL730km666SZNmDBB1113nZKSkrR27VrX89HR0Vq/fr2io6Nlt9v161//WnfeeaeeeeYZ15jevXsrOztbW7Zs0RVXXKEXX3xRq1atUlpaWjC+ElrB2XkmiSJrAIBfBH0fonDAPkShIe/ISd3x+q4G19+5Z7QrYAIAwCms9iECvEWRNQDAXwiIEDY43gMA4C9BK6oGWqN+kTXHewAAfIGACGEnOT7WLeh5d3exq9iazjMAQGuwZIawxvEeAABfICBCWON4DwCALxAQIazReQYA8AUCIoQ1jvcAAPgCRdUIexzvAQC4WGSIEBE43gMAcDEIiBBRKLIGALQGAREiCkXWAIDWICBCRGnqeI+SikoKrQEAHlFUjYjj6XgPdrMGADSFDBEikrPI2pkZotAaANAUAiJEPAqtAQDNISBCxKPQGgDQHAIiRLymCq0BAJAoqoZJeCq0lqSSikoVnTyj3l3bEyABgIkREME0kuNj3YIeOs8AAE4smcGU6DwDANRFQARTovMMAFAXARFMic4zAEBdBEQwpcY6zyRxvAcAmBBF1TCt+p1n2z8/oTGZORRZA4AJkSGCqTmP+JBEkTUAmBgBESCKrAHA7AiIAFFkDQBmR0AEqOnjPUoqKim0BoAIR1E18HeejvdgN2sAMAcyREAdziJrZ2aIQmsAMAcCIqARFFoDgHkQEAGNoNAaAMyDgAhoBLtZA4B5UFQNNIHdrAHAHMgQAc1gN2sAiHwERICXKLIGgMhFQAR4iSJrAIhcBESAl5razRoAEN4oqgZawNNu1pJUUlGpopNn1LtrewIkAAhDBERACyXHx7oFPRzvAQDhjyUz4CJwvAcARAYCIuAi0HkGAJGBgAi4CHSeAUBkICACLgKdZwAQGSiqBi6Sp84zus4AILwQEAE+ULfzjK4zAAg/LJkBPkTXGQCEJwIiwIfoOgOA8ERABPgQXWcAEJ4IiAAfaqrrrKSiUnlHTrJ8BgAhiKJqwMc8dZ1RaA0AoY0MEeAHyfGxsvfp4soMUWgNAKEtqAHRihUrNHToUNlsNtlsNtntdm3cuNH1/NmzZ5WRkaEuXbqoQ4cOmjBhgsrKytzeo7i4WOnp6YqLi1NCQoLmz5+v8+fPu43Jzc3V8OHDFRMTo759+yorKysQXw+QRKE1AISDoAZE3bt3V2ZmpgoKCvSXv/xFP/vZz3TLLbdo//79kqS5c+fqww8/1Pvvv69t27bp2LFjGj9+vOv1NTU1Sk9PV3V1tfLy8vTWW28pKytLTz75pGtMUVGR0tPTNW7cOBUWFmrOnDmaMWOGNm/eHPDvC3Oi0BoAQp/FMAyj+WGB07lzZz3//POaOHGiunXrptWrV2vixImSpEOHDmngwIHKz8/X6NGjtXHjRt100006duyYEhMTJUkrV67UggULdOLECVmtVi1YsEDZ2dnat2+f6zMmT56s8vJybdq0yas5ORwOxcfHq6KiQjabzfdfGhHv3d3FenTtPtUYhqvQmhoiAPCvlvx+h0wNUU1NjdasWaMzZ87IbreroKBA586dU2pqqmvMgAED1LNnT+Xn50uS8vPzNWTIEFcwJElpaWlyOByuLFN+fr7bezjHON/Dk6qqKjkcDrcHcDEmXdVTOx4Zp3fuGa0dj4zTpKt60nUGACEk6F1me/fuld1u19mzZ9WhQwetW7dOgwYNUmFhoaxWqzp16uQ2PjExUaWlpZKk0tJSt2DI+bzzuabGOBwOVVZWKja24TlTixcv1tNPP+2rrwhI4ngPAAhlQc8Q9e/fX4WFhdq1a5dmzZqladOm6cCBA0Gd08KFC1VRUeF6HD16NKjzQWSh6wwAQk/QM0RWq1V9+/aVJI0YMUK7d+/W0qVLNWnSJFVXV6u8vNwtS1RWVqakpCRJUlJSkj799FO393N2odUdU78zraysTDabzWN2SJJiYmIUExPjk+8H1NdU15kzgwQACKygZ4jqq62tVVVVlUaMGKG2bdtq69atrucOHz6s4uJi2e12SZLdbtfevXt1/Phx15gtW7bIZrNp0KBBrjF138M5xvkeQKDRdQYAoSeoAdHChQu1fft2ffXVV9q7d68WLlyo3NxcTZkyRfHx8Zo+fbrmzZunjz/+WAUFBbrrrrtkt9s1evRoSdINN9ygQYMGaerUqfq///s/bd68WY8//rgyMjJcGZ6ZM2fqyy+/1MMPP6xDhw5p+fLleu+99zR37txgfnWYWFPHewAAgiOoS2bHjx/XnXfeqZKSEsXHx2vo0KHavHmz/vEf/1GS9NJLLykqKkoTJkxQVVWV0tLStHz5ctfro6OjtX79es2aNUt2u13t27fXtGnT9Mwzz7jG9O7dW9nZ2Zo7d66WLl2q7t27a9WqVUpLSwv49wWcPB3vIV2oLyo6eUa9u7YnQAKAAAq5fYhCEfsQIRDoPAMA3wrIPkRffPGFNm/erMrKC50xxFVA69F5BgDB1eKA6Ntvv1Vqaqr69eunG2+8USUlJZKk6dOn68EHH/T5BAEz4LwzAAiuFgdEc+fOVZs2bVRcXKy4uB+7YiZNmuT1URgA3NF5BgDB1eKA6M9//rN+//vfq3v37m7Xf/KTn+jrr7/22cQAM6HzDACCq8VdZmfOnHHLDDmdOnWKzQyBi0DnGQAET4szRGPHjtV//Md/uP62WCyqra3VkiVLNG7cOJ9ODjCb5PhY2ft0cTvzbExmju54fZfGZObo3d3FQZ4hAESmFmeIlixZop///Of6y1/+ourqaj388MPav3+/Tp06pZ07d/pjjoApNdZ5dl2/bmSKAMDHWpwhGjx4sD7//HNde+21uuWWW3TmzBmNHz9ee/bsUZ8+ffwxR8CU6DwDgMBp1U7V8fHxeuyxx5occ9999+mZZ55R165dWzUxwOycnWd1gyI6zwDAP/x2ltl//dd/yeFw+OvtgYhH5xkABI7fzjJj52rg4jXWeQYA8K2gHu4KoHnJ8bFugRBt+ADgewREQBjhAFgA8A+/1RAB8C0OgAUA/2lxQFRcXOyxPsgwDBUXs2kc4C+04QOA/7Q4IOrdu7dOnDjR4PqpU6fUu3dv19+//vWvZbPZLm52AFw4ABYA/KfFAZFhGLJYLA2uf//992rXrp3r7xUrVrAHEeBDtOEDgP94XVQ9b948SRfOLnviiSfcDnitqanRrl27NGzYMJ9PEMCPOAAWAPzD64Boz549ki5kiPbu3Sur1ep6zmq16oorrtBDDz3k+xkCcFO/DZ/OMwC4eF4HRB9//LEk6a677tLSpUupDwJCAAfAAoBvtLiG6M033yQYAkIEnWcA4BvsQwSEMTrPAMA3CIiAMEbnGQD4Bkd3AGHOU+cZXWcA0DIEREAEqNt5RtcZALQcS2ZABOG8MwBoHQIiIILQdQYArUNABEQQus4AoHUIiIAIQtcZALQORdVAhOG8MwBoOQIiIAJx3hkAtAxLZkCEo/MMAJpHQAREODrPAKB5BERAhKPzDACaR0AERDg6zwCgeRRVAybAeWcA0DQCIsAkOO8MABrHkhlgMnSdAUBDBESAydB1BgANERABJkPXGQA0REAEmAxdZwDQEEXVgAlx3hkAuCMgAkyK884A4EcsmQGg8wyA6REQAaDzDIDpERABoPMMgOkREAFotPNMkvKOnGTpDEDEo6gagKSGnWfbPz+hMZk5FFkDMAUyRABckuNjZe/TRZIosgZgKgREABqgyBqA2RAQAWiAImsAZkNABKCBpo73KKmopNAaQMShqBqAR56O92A3awCRKqgZosWLF+uqq65Sx44dlZCQoFtvvVWHDx92G3P27FllZGSoS5cu6tChgyZMmKCysjK3McXFxUpPT1dcXJwSEhI0f/58nT9/3m1Mbm6uhg8frpiYGPXt21dZWVn+/npA2HMWWTszQxRaA4hUQQ2Itm3bpoyMDH3yySfasmWLzp07pxtuuEFnzpxxjZk7d64+/PBDvf/++9q2bZuOHTum8ePHu56vqalRenq6qqurlZeXp7feektZWVl68sknXWOKioqUnp6ucePGqbCwUHPmzNGMGTO0efPmgH5fIJxRaA0gklkMwzCaHxYYJ06cUEJCgrZt26brrrtOFRUV6tatm1avXq2JEydKkg4dOqSBAwcqPz9fo0eP1saNG3XTTTfp2LFjSkxMlCStXLlSCxYs0IkTJ2S1WrVgwQJlZ2dr3759rs+aPHmyysvLtWnTpmbn5XA4FB8fr4qKCtlsNv98eSDElVRUuvYlcoq2WLTjkXGSLgRMvbu2dzswFgCCqSW/3yFVVF1RUSFJ6ty5sySpoKBA586dU2pqqmvMgAED1LNnT+Xn50uS8vPzNWTIEFcwJElpaWlyOBzav3+/a0zd93COcb5HfVVVVXI4HG4PwOwaK7R2buB4x+u7NCYzR+/uLg7yTAGg5UKmqLq2tlZz5szRmDFjNHjwhSMDSktLZbVa1alTJ7exiYmJKi0tdY2pGww5n3c+19QYh8OhyspKxca6/3+0ixcv1tNPP+2z7wZEivqF1pLcskbOuqLr+nUjUwQgrIRMhigjI0P79u3TmjVrgj0VLVy4UBUVFa7H0aNHgz0lIGTULbSmrghApAiJDNHs2bO1fv16bd++Xd27d3ddT0pKUnV1tcrLy92yRGVlZUpKSnKN+fTTT93ez9mFVndM/c60srIy2Wy2BtkhSYqJiVFMTIxPvhsQyZwbONavK2IDRwDhJqgZIsMwNHv2bK1bt045OTnq3bu32/MjRoxQ27ZttXXrVte1w4cPq7i4WHa7XZJkt9u1d+9eHT9+3DVmy5YtstlsGjRokGtM3fdwjnG+B4DWaayuSBKbNwIIK0HtMrvvvvu0evVq/c///I/69+/vuh4fH+/K3MyaNUsbNmxQVlaWbDab7r//fklSXl6epAtt98OGDVNKSoqWLFmi0tJSTZ06VTNmzNBzzz0n6ULb/eDBg5WRkaG7775bOTk5euCBB5Sdna20tLRm50mXGdC0kopKV13R9s9PsHkjgJDQkt/voAZEFovF4/U333xTv/nNbyRd2JjxwQcf1DvvvKOqqiqlpaVp+fLlruUwSfr66681a9Ys5ebmqn379po2bZoyMzPVps2PK4K5ubmaO3euDhw4oO7du+uJJ55wfUZzCIgA7zTVmk+RNYBAC5uAKFwQEAHeyTtyUne8vqvB9XfuGS17ny5BmBEAMwvbfYgAhDdnkXVdziJrDoUFEMoIiAD4DJs3AghXLJl5gSUzoGXqFllLoq4IQFC05Pc7JPYhAhBZkuNjXcFO3pGTHjdvLPjqO3XuwPlnAEIDAREAv/K0eaNF0gNr9tCaDyBkUEMEwK/q1xU5/6NT//wziq0BBBMZIgB+V/dQ2G/PVGn26j1uzzvPP2PpDECwEBABCAhnXVFJRWWj55+VVFSq6CR1RQACjyUzAAFFaz6AUETbvRdouwd8j9Z8AP5G2z2AkOdNaz51RQAChSUzAEHX2JEfcdYojvsAEBAERACCzlNd0a1Xpui25XnUFAEICGqIvEANERAYzrqiOGuUblueR00RgItCDRGAsOSsK2qqpkgSrfkAfI6ACEDI8XTcR7TFor/+v3JNWfUJR34A8DlqiACEHE81RQ//or9+v/EQR34A8AsyRABCUt3jPnp1jVPRyTO05gPwGwIiACGr7l5Fkjwuozlb86kpAnAxWDIDEBZozQfgT7Tde4G2eyB00JoPwFu03QOIWLTmA/AHAiIAYYnWfAC+RA0RgLBEaz4AXyJDBCBs0ZoPwFcIiACENW9a83t1jVNJRSV1RQAaxZIZgIjhaRntufGDtf3zExqTmUN7PoBG0XbvBdrugfDibM3v1TVOkjQmM4f2fMCEaLsHYGp1l9Eaa88v+Oo7de7AEhqACwiIAEQ0T+35FkkPrNlDaz4AF2qIAES0+nVFzv/o0ZoPoC4yRAAiXt32/G/PVGn26j1uz9OaD4CACIApOOuKSioqac0H0ABLZgBMhdZ8AJ7Qdu8F2u6ByENrPhD5aLsHgGbQmg+gLgIiAKZHaz4AaogAmB6t+QDIEAGAvG/Nl0QnGhCBCIgA4O+aa83/6/8r15RVn7CMBkQglswAoB5PrfkP/6K/fr/xEMtoQIQiQwQAHtRdQuvVNU5FJ8947ERjh2sgMhAQAUAj6rbmS/K4jBZnjVLekZPUFAFhjiUzAPCCp2W0W69M0W3L89jdGogA7FTtBXaqBuDk3OE6zhql25bnsbs1EMLYqRoA/MS5jNbY7ta05gPhiYAIAFrB0+7WtOYD4YsaIgBoBVrzgchChggAWsnb1nwOiQVCHwERAFyE5lrzOSQWCA8smQGAj3BILBC+yBABgA9xSCwQnoKaIdq+fbtuvvlmpaSkyGKx6IMPPnB73jAMPfnkk0pOTlZsbKxSU1P1t7/9zW3MqVOnNGXKFNlsNnXq1EnTp0/X999/7zbmr3/9q8aOHat27dqpR48eWrJkib+/GgATS46Plb1PF4249BJFWdyfc3aijcnMYUNHIIQENSA6c+aMrrjiCi1btszj80uWLNErr7yilStXateuXWrfvr3S0tJ09uxZ15gpU6Zo//792rJli9avX6/t27fr3nvvdT3vcDh0ww036NJLL1VBQYGef/55PfXUU3rttdf8/v0AmBudaED4CJmdqi0Wi9atW6dbb71V0oXsUEpKih588EE99NBDkqSKigolJiYqKytLkydP1sGDBzVo0CDt3r1bI0eOlCRt2rRJN954o7755hulpKRoxYoVeuyxx1RaWiqr1SpJeuSRR/TBBx/o0KFDXs2NnaoBXAzn7tbOTrQ7Xt/VYMw794x2Pc8yGuAbLfn9Dtmi6qKiIpWWlio1NdV1LT4+XqNGjVJ+fr4kKT8/X506dXIFQ5KUmpqqqKgo7dq1yzXmuuuucwVDkpSWlqbDhw/ru+++C9C3AWBmziW05PhY14aOdbGMBgRfyAZEpaWlkqTExES364mJia7nSktLlZCQ4PZ8mzZt1LlzZ7cxnt6j7mfUV1VVJYfD4fYAAF9oyTLa/x39TnlHTrKcBgQAXWYeLF68WE8//XSwpwEgQnm7oeOty/NksH8REBAhmyFKSkqSJJWVlbldLysrcz2XlJSk48ePuz1//vx5nTp1ym2Mp/eo+xn1LVy4UBUVFa7H0aNHL/4LAUAdzS2jSZJB4TUQMCEbEPXu3VtJSUnaunWr65rD4dCuXbtkt9slSXa7XeXl5SooKHCNycnJUW1trUaNGuUas337dp07d841ZsuWLerfv78uueQSj58dExMjm83m9gAAf2lsQ8e6nPsXlVRUsowG+EFQl8y+//57ffHFF66/i4qKVFhYqM6dO6tnz56aM2eOnn32Wf3kJz9R79699cQTTyglJcXViTZw4ED94he/0D333KOVK1fq3Llzmj17tiZPnqyUlBRJ0h133KGnn35a06dP14IFC7Rv3z4tXbpUL730UjC+MgB4VHcZLc4apduW57ktozkLr6es+oRjQAA/CGrbfW5ursaNG9fg+rRp05SVlSXDMLRo0SK99tprKi8v17XXXqvly5erX79+rrGnTp3S7Nmz9eGHHyoqKkoTJkzQK6+8og4dOrjG/PWvf1VGRoZ2796trl276v7779eCBQu8nidt9wAC7d3dxXp07T7VGMaPhdebDjUIktbeZ9eZ6hpa9QEPWvL7HTL7EIUyAiIAweDN/kUWiyi8BhrRkt9vuswAIEQlx8e6ZX2iLGrQjVa/8Pq6ft0kcU4a0FIERAAQBpyF185ltChJtfXG1BiG3tzxlVbt+JI6I6CFWDLzAktmAEKFcxnNU+F1lCTVyyJRZwQzo4bIxwiIAISi+oXX06/tpdf+t6jBOE91RiUVlSyrIeJRQwQAJlB/x2tJWrWjqNk6o/LKc66jQlhWAy4gQ+QFMkQAwkXdrJGnOiPpx4yRE8tqiFQsmfkYARGAcNJcnVFTQRLLaogkLJkBgInVbdev25nW2AaPEstqABkiL5AhAhDO6m7wmBwf2+pltR2PXDhZgKwRwgUZIgCAS/0NHps7Ny1KDTeAbGyPo+v6dSNAQkQgQ+QFMkQAIpk356Z52uPIoguZpPrLatQeIVSQIQIAeK1++35yfKw6xbVtdo8jQ97VHpFFQjggQ+QFMkQAzKhu7ZEkjcnMabCUVl/92iOySAgmMkQAgItWv/ao/llqxt8fTp5qj8giIVyQIfICGSIAuKBu1mj75ye8aumvjywSAoUMEQDAL+pmjZqrPfJ1Fol9kOBPZIi8QIYIALznjywSx4ugNTi6w8cIiACg9ZrbGNJjFsnD+3C8CFqKgMjHCIgAwLcuNosUbbHo4V/297isRpAEJwIiHyMgAgD/8tXxIp6CJDrYzIuAyMcIiAAg8JxBUqPHi3h4DR1sqIsuMwBA2Kvb0VZ3D6SmjhdhHyS0FhkiL5AhAoDga2pZjX2Q4AkZIgBAxKm/c3ag90EiixTZyBB5gQwRAIQPdtOGExkiAIBpBXM3bbJI4YsMkRfIEAFAZCGLZA5kiAAAaEKwz2QjSAo9ZIi8QIYIAMzHX2eysXlk4LAxo48REAEAfH0mm+tvsdTmLwREPkZABADwpKVZpMaCpLrIIvkOAZGPERABALzB5pGhhaJqAACCgM0jwxcZIi+QIQIA+FIg2/7NjAwRAAAhLFBt/9f16yZJZI28QEAEAECQNbfU1posUo1h6M0dX2nVji9ZVvMCS2ZeYMkMABBsrWn7l8U9k2S24my6zHyMgAgAEIqaqkWafm0vvfa/RU2+vrEW/0gJkgiIfIyACAAQDuoGSJI0JjPHZ7tph2OBNgGRjxEQAQDCka920462WLT2PrvOVNeEVcaIgMjHCIgAAOHKV7tpO4OkcFpWo+0eAABIalmLf1MdbN5sDBmOy2pOZIi8QIYIABDJmutgC9dlNZbMfIyACABgNs4gKc4apduW54XlshpLZgAA4KLUXWpbPH5IxC+rkSHyAhkiAIDZheOyGktmPkZABABAQ75aVvOXlvx+R/ltFgAAIKIlx8fK3qeLruhxiRaPH6Joi0XShUzQgl8OUJSl4WvqL6uVVFSqpKJSeUdOqqSiMoCzd0cNEQAAuGjNtfR7yhg1dgBtMOqMWDLzAktmAAC0TnPLavUPoI22WLTjkXE+qS9iyQwAAISEppbVZozt3aBTrcYw9NXJHwI+T5bMAABAQNRfVpOkVTuKGmSInM8FEhkiAAAQMM6MkXOfo/pZo+fGDw7KLtemyhAtW7ZMzz//vEpLS3XFFVfo1Vdf1dVXXx3saQEAYFqeirGDwTQZonfffVfz5s3TokWL9Nlnn+mKK65QWlqajh8/HuypAQBganWzRsFimoDoD3/4g+655x7dddddGjRokFauXKm4uDi98cYbwZ4aAAAIMlMERNXV1SooKFBqaqrrWlRUlFJTU5Wfnx/EmQEAgFBgihqikydPqqamRomJiW7XExMTdejQoQbjq6qqVFVV5frb4XD4fY4AACB4TJEhaqnFixcrPj7e9ejRo0ewpwQAAPzIFAFR165dFR0drbKyMrfrZWVlSkpKajB+4cKFqqiocD2OHj0aqKkCAIAgMEVAZLVaNWLECG3dutV1rba2Vlu3bpXdbm8wPiYmRjabze0BAAAilylqiCRp3rx5mjZtmkaOHKmrr75aL7/8ss6cOaO77ror2FMDAABBZpqAaNKkSTpx4oSefPJJlZaWatiwYdq0aVODQmsAAGA+nHbvBU67BwAg/HDaPQAAQAsQEAEAANMzTQ3RxXCuKrJBIwAA4cP5u+1NdRABkRdOnz4tSWzQCABAGDp9+rTi4+ObHENRtRdqa2t17NgxdezYURaLxSfv6XA41KNHDx09epRCbT/iPgcO9zpwuNeBwX0OHH/da8MwdPr0aaWkpCgqqukqITJEXoiKilL37t398t5s/BgY3OfA4V4HDvc6MLjPgeOPe91cZsiJomoAAGB6BEQAAMD0CIiCJCYmRosWLVJMTEywpxLRuM+Bw70OHO51YHCfAycU7jVF1QAAwPTIEAEAANMjIAIAAKZHQAQAAEyPgMiPli1bpl69eqldu3YaNWqUPv300ybHv//++xowYIDatWunIUOGaMOGDQGaaXhryX1+/fXXNXbsWF1yySW65JJLlJqa2uz/XfCjlv477bRmzRpZLBbdeuut/p1ghGjpfS4vL1dGRoaSk5MVExOjfv368d8PL7X0Xr/88svq37+/YmNj1aNHD82dO1dnz54N0GzD0/bt23XzzTcrJSVFFotFH3zwQbOvyc3N1fDhwxUTE6O+ffsqKyvL7/OUAb9Ys2aNYbVajTfeeMPYv3+/cc899xidOnUyysrKPI7fuXOnER0dbSxZssQ4cOCA8fjjjxtt27Y19u7dG+CZh5eW3uc77rjDWLZsmbFnzx7j4MGDxm9+8xsjPj7e+OabbwI88/DT0nvtVFRUZPzDP/yDMXbsWOOWW24JzGTDWEvvc1VVlTFy5EjjxhtvNHbs2GEUFRUZubm5RmFhYYBnHn5aeq/ffvttIyYmxnj77beNoqIiY/PmzUZycrIxd+7cAM88vGzYsMF47LHHjLVr1xqSjHXr1jU5/ssvvzTi4uKMefPmGQcOHDBeffVVIzo62ti0aZNf50lA5CdXX321kZGR4fq7pqbGSElJMRYvXuxx/O23326kp6e7XRs1apTxL//yL36dZ7hr6X2u7/z580bHjh2Nt956y19TjBitudfnz583rrnmGmPVqlXGtGnTCIi80NL7vGLFCuOyyy4zqqurAzXFiNHSe52RkWH87Gc/c7s2b948Y8yYMX6dZyTxJiB6+OGHjcsvv9zt2qRJk4y0tDQ/zswwWDLzg+rqahUUFCg1NdV1LSoqSqmpqcrPz/f4mvz8fLfxkpSWltboeLTuPtf3ww8/6Ny5c+rcubO/phkRWnuvn3nmGSUkJGj69OmBmGbYa819/tOf/iS73a6MjAwlJiZq8ODBeu6551RTUxOoaYel1tzra665RgUFBa5ltS+//FIbNmzQjTfeGJA5m0Wwfg85y8wPTp48qZqaGiUmJrpdT0xM1KFDhzy+prS01OP40tJSv80z3LXmPte3YMECpaSkNPgfH9y15l7v2LFD//7v/67CwsIAzDAytOY+f/nll8rJydGUKVO0YcMGffHFF7rvvvt07tw5LVq0KBDTDkutudd33HGHTp48qWuvvVaGYej8+fOaOXOmHn300UBM2TQa+z10OByqrKxUbGysXz6XDBFMKzMzU2vWrNG6devUrl27YE8nopw+fVpTp07V66+/rq5duwZ7OhGttrZWCQkJeu211zRixAhNmjRJjz32mFauXBnsqUWc3NxcPffcc1q+fLk+++wzrV27VtnZ2frtb38b7KnBB8gQ+UHXrl0VHR2tsrIyt+tlZWVKSkry+JqkpKQWjUfr7rPTCy+8oMzMTH300UcaOnSoP6cZEVp6r48cOaKvvvpKN998s+tabW2tJKlNmzY6fPiw+vTp499Jh6HW/DudnJystm3bKjo62nVt4MCBKi0tVXV1taxWq1/nHK5ac6+feOIJTZ06VTNmzJAkDRkyRGfOnNG9996rxx57TFFR5Bh8obHfQ5vN5rfskESGyC+sVqtGjBihrVu3uq7V1tZq69atstvtHl9jt9vdxkvSli1bGh2P1t1nSVqyZIl++9vfatOmTRo5cmQgphr2WnqvBwwYoL1796qwsND1+NWvfqVx48apsLBQPXr0COT0w0Zr/p0eM2aMvvjiC1fAKUmff/65kpOTCYaa0Jp7/cMPPzQIepyBqMEpWD4TtN9Dv5Zsm9iaNWuMmJgYIysryzhw4IBx7733Gp06dTJKS0sNwzCMqVOnGo888ohr/M6dO402bdoYL7zwgnHw4EFj0aJFtN17oaX3OTMz07BarcZ///d/GyUlJa7H6dOng/UVwkZL73V9dJl5p6X3ubi42OjYsaMxe/Zs4/Dhw8b69euNhIQE49lnnw3WVwgbLb3XixYtMjp27Gi88847xpdffmn8+c9/Nvr06WPcfvvtwfoKYeH06dPGnj17jD179hiSjD/84Q/Gnj17jK+//towDMN45JFHjKlTp7rGO9vu58+fbxw8eNBYtmwZbffh7tVXXzV69uxpWK1W4+qrrzY++eQT13PXX3+9MW3aNLfx7733ntGvXz/DarUal19+uZGdnR3gGYenltznSy+91JDU4LFo0aLATzwMtfTf6boIiLzX0vucl5dnjBo1yoiJiTEuu+wy43e/+51x/vz5AM86PLXkXp87d8546qmnjD59+hjt2rUzevToYdx3333Gd999F/iJh5GPP/7Y4393nfd22rRpxvXXX9/gNcOGDTOsVqtx2WWXGW+++abf58lp9wAAwPSoIQIAAKZHQAQAAEyPgAgAAJgeAREAADA9AiIAAGB6BEQAAMD0CIgAAIDpERABAADTIyAC4Fe5ubmyWCwqLy8P9lQAoFEERADCnsVi0QcffBDsaQAIYwREAPyquro62FPw2rlz50z1uQB+REAEwKd++tOfavbs2ZozZ466du2qtLQ0SVJBQYFGjhypuLg4XXPNNTp8+LDb61asWKE+ffrIarWqf//++s///E+vPq9Xr16SpNtuu00Wi8X1tzfvabFYtGLFCv3qV79S+/bt9bvf/a7Jz3Iu/23duvWivounz33qqac0bNgwvfHGG+rZs6c6dOig++67TzU1NVqyZImSkpKUkJDQ7BwBtJLfj48FYCrXX3+90aFDB2P+/PnGoUOHjJUrVxqSjFGjRhm5ubnG/v37jbFjxxrXXHON6zVr16412rZtayxbtsw4fPiw8eKLLxrR0dFGTk5Os593/PhxQ5Lx5ptvGiUlJcbx48e9fk9JRkJCgvHGG28YR44cMb7++usmP8t5avfFfhdPn7to0SKjQ4cOxsSJE439+/cbf/rTnwyr1WqkpaUZ999/v3Ho0CHjjTfeMCS5ncgOwDcIiAD41PXXX29ceeWVrr+dQcRHH33kupadnW1IMiorKw3DMIxrrrnGuOeee9ze55/+6Z+MG2+80avPlGSsW7fO7Zo37ynJmDNnjlef4cvv4ulzFy1aZMTFxRkOh8N1LS0tzejVq5dRU1Pjuta/f39j8eLFXs8ZgHdYMgPgcyNGjGhwbejQoa5/Tk5OliQdP35cknTw4EGNGTPGbfyYMWN08ODBVs/B2/ccOXJki9/bF9/F0+f26tVLHTt2dP2dmJioQYMGKSoqyu2a87MA+A4BEQCfa9++fYNrbdu2df2zxWKRJNXW1gZsTo3xNNfm+OK7NHePnO/t6Voo3Dcg0hAQAQi6gQMHaufOnW7Xdu7cqUGDBnn1+rZt26qmpsan79lawfpcABenTbAnAADz58/X7bffriuvvFKpqan68MMPtXbtWn300Udevb5Xr17aunWrxowZo5iYGF1yySUX/Z7B+i4AgoMMEYCgu/XWW7V06VK98MILuvzyy/XHP/5Rb775pn7605969foXX3xRW7ZsUY8ePXTllVf65D1bK1ifC+DiWAzDMII9CQAAgGAiQwQAAEyPgAhASHv77bfVoUMHj4/LL7/cp581c+bMRj9r5syZPv0sAKGFJTMAIe306dMqKyvz+Fzbtm116aWX+uyzjh8/LofD4fE5m82mhIQEn30WgNBCQAQAAEyPJTMAAGB6BEQAAMD0CIgAAIDpERABAADTIyACAACmR0AEAABMj4AIAACYHgERAAAwvf8P3JmfkqxLWEoAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "ds_out = run.data_out.get_variables(('time', 'rho_tor_norm', 't_e'))\n",
+    "\n",
+    "ds_out.isel(time=[\n",
+    "    0,\n",
+    "]).plot.scatter('rho_tor_norm', 't_e', marker='.')"
    ]
   }
  ],

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,7 @@ nav:
     - examples/xarray.ipynb
     - examples/xarray-2D.ipynb
     - examples/xarray-ions.ipynb
+    - examples/create_api.ipynb
     - examples/demo_single_run.ipynb
     - examples/demo_lsv_run.ipynb
     - examples/duqtools_on_prominence.ipynb

--- a/src/duqtools/__init__.py
+++ b/src/duqtools/__init__.py
@@ -21,8 +21,6 @@ __version__ = '1.7.0'
 import logging  # noqa
 import warnings  # noqa
 
-logging.basicConfig(level=logging.INFO)
-
 # https://github.com/duqtools/duqtools/issues/264
 warnings.filterwarnings(
     'ignore',

--- a/src/duqtools/_logging_utils.py
+++ b/src/duqtools/_logging_utils.py
@@ -62,6 +62,3 @@ def initialize_duqlog_screen():
     stream = logging.StreamHandler()
     stream.setFormatter(logging.Formatter('%(message)s'))
     duqlog_screen.addHandler(stream)
-
-
-initialize_duqlog_screen()

--- a/src/duqtools/api.py
+++ b/src/duqtools/api.py
@@ -29,7 +29,7 @@ from .ids import (
     rebase_on_time,
     standardize_grid_and_time,
 )
-from .models import Run, Runs
+from .models import Job, Run, Runs
 from .schema import IDSVariableModel as Variable
 
 __all__ = [
@@ -41,6 +41,7 @@ __all__ = [
     'standardize_grid_and_time',
     'ImasHandle',
     'IDSMapping',
+    'Job',
     'Variable',
     'alt_line_chart',
     'alt_errorband_chart',

--- a/src/duqtools/api.py
+++ b/src/duqtools/api.py
@@ -19,6 +19,7 @@ Plotting:
 """
 
 from ._plot_utils import alt_errorband_chart, alt_line_chart
+from .create import create_api as create
 from .duqmap import duqmap
 from .ids import (
     IDSMapping,
@@ -32,6 +33,7 @@ from .models import Run, Runs
 from .schema import IDSVariableModel as Variable
 
 __all__ = [
+    'create',
     'duqmap',
     'rebase_on_grid',
     'rebase_on_time',

--- a/src/duqtools/cli.py
+++ b/src/duqtools/cli.py
@@ -10,7 +10,7 @@ from pydantic import ValidationError
 
 from ._click_opt_groups import GroupCmd, GroupOpt
 from ._logging_utils import TermEscapeCodeFormatter, duqlog_screen, initialize_duqlog_screen
-from .config import cfg, load_config
+from .config import CFG, load_config
 from .operations import op_queue, op_queue_context
 
 logging.basicConfig(level=logging.INFO)
@@ -165,7 +165,7 @@ class OptionParser:
     def parse_quiet(self, *, quiet, **kwargs):
         if quiet:
             duqlog_screen.handlers = []  # remove output methods
-            cfg.quiet = True
+            CFG.quiet = True
 
     def parse_dry_run(self, *, dry_run, **kwargs):
         op_queue.dry_run = dry_run

--- a/src/duqtools/cli.py
+++ b/src/duqtools/cli.py
@@ -9,9 +9,12 @@ import click
 from pydantic import ValidationError
 
 from ._click_opt_groups import GroupCmd, GroupOpt
-from ._logging_utils import TermEscapeCodeFormatter, duqlog_screen
+from ._logging_utils import TermEscapeCodeFormatter, duqlog_screen, initialize_duqlog_screen
 from .config import cfg, load_config
 from .operations import op_queue, op_queue_context
+
+logging.basicConfig(level=logging.INFO)
+initialize_duqlog_screen()
 
 logger = logging.getLogger(__name__)
 

--- a/src/duqtools/config/__init__.py
+++ b/src/duqtools/config/__init__.py
@@ -1,8 +1,8 @@
-from ._config import Config, cfg, load_config
+from ._config import CFG, Config, load_config
 from ._variables import lookup_vars, var_lookup
 
 __all__ = [
-    'cfg',
+    'CFG',
     'Config',
     'load_config',
     'lookup_vars',

--- a/src/duqtools/config/_config.py
+++ b/src/duqtools/config/_config.py
@@ -19,23 +19,35 @@ from ..schema.cli import ConfigModel
 class Config(ConfigModel):
     ...
 
+    @staticmethod
+    def _update_global_config(new_cfg: Config):
+        from ._variables import var_lookup
+
+        if new_cfg.extra_variables:
+            var_lookup.update(new_cfg.extra_variables.to_variable_dict())
+
+        cfg.__dict__.update(new_cfg.__dict__)
+
+    @classmethod
+    def from_dict(cls, mapping: dict):
+        new_cfg = cls.parse_obj(mapping)
+        cls._update_global_config(new_cfg)
+        return new_cfg
+
+    @classmethod
+    def from_file(cls, path: Union[str, Path]):
+        new_cfg = cls.parse_file(path)
+
+        cls._update_global_config(new_cfg)
+
+        for obj in (cfg, new_cfg):
+            obj._path = path
+
+        return new_cfg
+
 
 def load_config(path: Union[str, Path]) -> Config:
-    global cfg
-
-    new_cfg = Config.parse_file(path)
-
-    from ._variables import var_lookup
-
-    if new_cfg.extra_variables:
-        var_lookup.update(new_cfg.extra_variables.to_variable_dict())
-
-    cfg.__dict__.update(new_cfg.__dict__)
-
-    for obj in (cfg, new_cfg):
-        obj._path = path
-
-    return new_cfg
+    return Config.from_file(path)
 
 
 cfg = Config.construct()

--- a/src/duqtools/config/_config.py
+++ b/src/duqtools/config/_config.py
@@ -1,7 +1,7 @@
 """Config class containing all configs, can be used with:
 
-    from duqtools.config import cfg
-    cfg.<variable you want>
+    from duqtools.config import CFG
+    CFG.<variable you want>
 
 To update the config:
 
@@ -17,37 +17,60 @@ from ..schema.cli import ConfigModel
 
 
 class Config(ConfigModel):
-    ...
 
     @staticmethod
-    def _update_global_config(new_cfg: Config):
+    def _update_global_config(cfg: Config):
         from ._variables import var_lookup
 
-        if new_cfg.extra_variables:
-            var_lookup.update(new_cfg.extra_variables.to_variable_dict())
+        if cfg.extra_variables:
+            var_lookup.update(cfg.extra_variables.to_variable_dict())
 
-        cfg.__dict__.update(new_cfg.__dict__)
-
-    @classmethod
-    def from_dict(cls, mapping: dict):
-        new_cfg = cls.parse_obj(mapping)
-        cls._update_global_config(new_cfg)
-        return new_cfg
+        CFG.__dict__.update(cfg.__dict__)
 
     @classmethod
-    def from_file(cls, path: Union[str, Path]):
-        new_cfg = cls.parse_file(path)
+    def from_dict(cls, mapping: dict) -> Config:
+        """Parse config from dictionary and update global config (CFG).
 
-        cls._update_global_config(new_cfg)
+        Parameters
+        ----------
+        path : Union[str, Path]
+            Path to config.
 
-        for obj in (cfg, new_cfg):
+        Returns
+        -------
+        cfg : Config
+            Return instance of Config class.
+        """
+        cfg = cls.parse_obj(mapping)
+        cls._update_global_config(cfg)
+        return cfg
+
+    @classmethod
+    def from_file(cls, path: Union[str, Path]) -> Config:
+        """Read config from file and update global config (CFG).
+
+        Parameters
+        ----------
+        path : Union[str, Path]
+            Path to config.
+
+        Returns
+        -------
+        cfg : Config
+            Return instance of Config class.
+        """
+        cfg = cls.parse_file(path)
+
+        cls._update_global_config(cfg)
+
+        for obj in (CFG, cfg):
             obj._path = path
 
-        return new_cfg
+        return cfg
 
 
 def load_config(path: Union[str, Path]) -> Config:
     return Config.from_file(path)
 
 
-cfg = Config.construct()
+CFG = Config.construct()

--- a/src/duqtools/create.py
+++ b/src/duqtools/create.py
@@ -193,14 +193,20 @@ class CreateManager:
         if self._is_runs_dir_different_from_config_dir():
             df.to_csv(self.runs_dir / fname)
 
-    @add_to_op_queue('Copying config to run directory', quiet=True)
     def copy_config(self):
         if self.cfg._path is None:
             return
 
         if self._is_runs_dir_different_from_config_dir():
-            shutil.copyfile(Path.cwd() / self.cfg._path,
-                            self.runs_dir / 'duqtools.yaml')
+            op_queue.add(
+                shutil.copyfile,
+                args=(
+                    Path.cwd() / self.cfg._path,
+                    self.runs_dir / 'duqtools.yaml',
+                ),
+                description='Copying config to run directory',
+                quiet=True,
+            )
 
     def _is_runs_dir_different_from_config_dir(self) -> bool:
         """Return True if the runs dir is different from the duqtools config

--- a/src/duqtools/create.py
+++ b/src/duqtools/create.py
@@ -281,15 +281,19 @@ def create(*,
 
 def create_entry(*args, **kwargs):
     """Entry point for duqtools cli."""
-    from .config import cfg
-    return create(cfg=cfg, *args, **kwargs)
+    from .config import CFG
+    return create(cfg=CFG, *args, **kwargs)
 
 
 def create_api(config: dict, **kwargs):
     """Wrapper around create for python api."""
     cfg = Config.from_dict(config)
     create(cfg=cfg, **kwargs)
+
+    assert cfg.create
+    assert cfg.create.runs_dir
     job = Job(cfg.create.runs_dir / 'run_0000')
+
     return job
 
 
@@ -303,8 +307,8 @@ def recreate(*, runs: Sequence[Path], **kwargs):
     **kwargs
         Unused.
     """
-    from ..config import cfg
-    create_mgr = CreateManager(cfg)
+    from .config import CFG
+    create_mgr = CreateManager(CFG)
 
     run_dict = {run.shortname: run for run in Locations().runs}
 

--- a/src/duqtools/create.py
+++ b/src/duqtools/create.py
@@ -199,7 +199,7 @@ class CreateManager:
 
         if self._is_runs_dir_different_from_config_dir():
             op_queue.add(
-                shutil.copyfile,
+                action=shutil.copyfile,
                 args=(
                     Path.cwd() / self.cfg._path,
                     self.runs_dir / 'duqtools.yaml',

--- a/src/duqtools/ids/_imas.py
+++ b/src/duqtools/ids/_imas.py
@@ -55,4 +55,5 @@ except (ModuleNotFoundError, ImportError):
 
     Parser = Mock()  # type: ignore
 
-    logger.warning('Could not import IMAS: using mocks instead.')
+if imas_mocked:
+    logger.info('Could not import IMAS, using mocks instead.')

--- a/src/duqtools/ids/_imas.py
+++ b/src/duqtools/ids/_imas.py
@@ -55,4 +55,4 @@ except (ModuleNotFoundError, ImportError):
 
     Parser = Mock()  # type: ignore
 
-    logger.warning('Could not import IMAS:', exc_info=True)
+    logger.warning('Could not import IMAS: using mocks instead.')

--- a/src/duqtools/jetto/_batchfile.py
+++ b/src/duqtools/jetto/_batchfile.py
@@ -74,7 +74,7 @@ def write_array_batchfile(jobs: Sequence[Job], max_jobs: int,
     max_jobs : int
         Maximum number of jobs to run at the same time.
     """
-    common_dir = Path(commonpath(job.dir for job in jobs))  # type: ignore
+    common_dir = Path(commonpath(job.path for job in jobs))  # type: ignore
     logs_dir = common_dir / 'logs'
     logs_dir.mkdir(exist_ok=True)
 

--- a/src/duqtools/jetto/_system.py
+++ b/src/duqtools/jetto/_system.py
@@ -89,8 +89,8 @@ class BaseJettoSystem(AbstractSystem):
     @staticmethod
     def submit_job(job: Job):
         # Make sure we get a new correct status
-        if (job.dir / 'jetto.status').exists():
-            os.remove(job.dir / 'jetto.status')
+        if (job.path / 'jetto.status').exists():
+            os.remove(job.path / 'jetto.status')
 
         submit_system = job.cfg.submit.submit_system
 
@@ -123,11 +123,11 @@ class BaseJettoSystem(AbstractSystem):
 
     @staticmethod
     def submit_docker(job: Job):
-        jetto_template = template.from_directory(job.dir)
+        jetto_template = template.from_directory(job.path)
         jetto_config = config.RunConfig(jetto_template)
         jetto_manager = jetto_job.JobManager()
         extra_volumes = {
-            job.dir.parent / 'imasdb': {
+            job.path.parent / 'imasdb': {
                 'bind': '/opt/imas/shared/imasdb',
                 'mode': 'rw'
             },
@@ -137,7 +137,7 @@ class BaseJettoSystem(AbstractSystem):
         os.environ['JINTRAC_IMAS_BACKEND'] = 'MDSPLUS'
         container = jetto_manager.submit_job_to_docker(
             jetto_config,
-            job.dir,
+            job.path,
             image=job.cfg.submit.docker_image,
             extra_volumes=extra_volumes)
         job.lockfile.touch()
@@ -146,12 +146,12 @@ class BaseJettoSystem(AbstractSystem):
 
     @staticmethod
     def submit_prominence(job: Job):
-        jetto_template = template.from_directory(job.dir)
+        jetto_template = template.from_directory(job.path)
         jetto_config = config.RunConfig(jetto_template)
         jetto_manager = jetto_job.JobManager()
 
         os.environ['RUNS_HOME'] = os.getcwd()
-        _ = jetto_manager.submit_job_to_prominence(jetto_config, job.dir)
+        _ = jetto_manager.submit_job_to_prominence(jetto_config, job.path)
 
     @staticmethod
     def submit_array(jobs: Sequence[Job],

--- a/src/duqtools/jetto/_system.py
+++ b/src/duqtools/jetto/_system.py
@@ -12,7 +12,7 @@ from jetto_tools import config, jset, lookup, namelist, template
 from jetto_tools import job as jetto_job
 from jetto_tools.template import _EXTRA_FILE_REGEXES
 
-from ..config import Config, cfg
+from ..config import CFG, Config
 from ..ids import ImasHandle
 from ..models import AbstractSystem, Job, Locations
 from ..operations import add_to_op_queue
@@ -64,7 +64,7 @@ class BaseJettoSystem(AbstractSystem):
     @staticmethod
     def get_runs_dir() -> Path:
         path = Locations().jruns_path
-        runs_dir = cfg.create.runs_dir  # type: ignore
+        runs_dir = CFG.create.runs_dir  # type: ignore
         if not runs_dir:
             abs_cwd = str(Path.cwd().resolve())
             abs_jruns = str(path.resolve())

--- a/src/duqtools/models/__init__.py
+++ b/src/duqtools/models/__init__.py
@@ -3,4 +3,11 @@ from ._locations import Locations
 from ._run import Run, Runs
 from ._system import AbstractSystem
 
-__all__ = ['Locations', 'AbstractSystem', 'Job', 'JobStatus', 'Run', 'Runs']
+__all__ = [
+    'Locations',
+    'AbstractSystem',
+    'Job',
+    'JobStatus',
+    'Run',
+    'Runs',
+]

--- a/src/duqtools/models/_job.py
+++ b/src/duqtools/models/_job.py
@@ -1,10 +1,12 @@
 import logging
 from enum import Enum
 from pathlib import Path
+from typing import Optional
 
 import click
 
-from ..config import cfg
+from ..config import Config
+from ..config import cfg as global_cfg
 
 logger = logging.getLogger(__name__)
 info, debug = logger.info, logger.debug
@@ -42,8 +44,12 @@ class JobStatus(str, Enum):
 
 class Job:
 
-    def __init__(self, dir: Path):
+    def __init__(self, dir: Path, cfg: Optional[Config] = None):
         self.dir = Path(dir).resolve()
+
+        if cfg is None:
+            cfg = global_cfg
+
         self.cfg = cfg
 
     def __repr__(self):

--- a/src/duqtools/models/_job.py
+++ b/src/duqtools/models/_job.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from enum import Enum
 from pathlib import Path
 from typing import Optional
@@ -43,13 +44,22 @@ class JobStatus(str, Enum):
 
 class Job:
 
-    def __init__(self, dir: Path, cfg: Optional[Config] = None):
-        self.dir = Path(dir).resolve()
+    def __init__(self, path: Path, *, cfg: Optional[Config] = None):
+        """Summary.
+
+        Parameters
+        ----------
+        path : Path
+            Directory for simulation or model run.
+        cfg : Optional[Config], optional
+            Duqtools config, defaults to global config if unspecified.
+        """
+        self.path = Path(path).resolve()
 
         self.cfg = cfg if cfg is not None else CFG
 
     def __repr__(self):
-        run = str(self.dir)
+        run = str(self.path)
         return f'{self.__class__.__name__}({run!r})'
 
     @staticmethod
@@ -64,17 +74,21 @@ class Job:
 
     @property
     def has_submit_script(self) -> bool:
+        """Return true if directory has submit script."""
         return self.submit_script.exists()
 
     @property
     def has_status(self) -> bool:
+        """Return true if a status file exists."""
         return self.status_file.exists()
 
     @property
     def is_submitted(self) -> bool:
-        return (self.dir / 'duqtools.submit.lock').exists()
+        """Return true if the job has been submitted."""
+        return (self.path / 'duqtools.submit.lock').exists()
 
     def status(self) -> str:
+        """Return the status of the job."""
         if not self.has_status:
             return JobStatus.NOSTATUS
 
@@ -95,37 +109,51 @@ class Job:
 
     @property
     def is_completed(self) -> bool:
+        """Return true if the job has been completed succesfully."""
         return self.status() == JobStatus.COMPLETED
 
     @property
     def is_failed(self) -> bool:
+        """Return true if the job has failed."""
         return self.status() == JobStatus.FAILED
 
     @property
     def is_running(self) -> bool:
+        """Return true if the job is running."""
         return self.status() == JobStatus.RUNNING
 
     @property
+    def is_done(self) -> bool:
+        """Return true if the job is done (completed or failed)."""
+        return self.status() in (JobStatus.COMPLETED or JobStatus.FAILED)
+
+    @property
     def in_file(self) -> Path:
-        return self.dir / self.cfg.status.in_file
+        """Return path to the input file for the job."""
+        return self.path / self.cfg.status.in_file
 
     @property
     def out_file(self) -> Path:
-        return self.dir / self.cfg.status.out_file
+        """Return path to the output file for the job."""
+        return self.path / self.cfg.status.out_file
 
     @property
     def status_file(self) -> Path:
-        return self.dir / self.cfg.status.status_file
+        """Return the path of the status file."""
+        return self.path / self.cfg.status.status_file
 
     @property
     def submit_script(self) -> Path:
-        return self.dir / self.cfg.submit.submit_script_name
+        """Return the path of the submit script."""
+        return self.path / self.cfg.submit.submit_script_name
 
     @property
     def lockfile(self) -> Path:
-        return self.dir / 'duqtools.submit.lock'
+        """Return the path of the lockfile."""
+        return self.path / 'duqtools.submit.lock'
 
     def submit(self):
+        """Submit job."""
         from ..system import get_system
         debug(f'Put lockfile in place for {self.lockfile}')
         self.lockfile.touch()
@@ -133,11 +161,21 @@ class Job:
         get_system().submit_job(self)
 
     def start(self):
+        """Submit job and return generate that raises StopIteration when
+        done."""
         click.echo(f'Submitting {self}\033[K')
         self.submit()
 
-        while not self.has_status:
+        while self.status() in (JobStatus.RUNNING, JobStatus.NOSTATUS):
             yield
 
-        while self.is_running:
-            yield
+    def wait_until_done(self, time_step: float = 1.0):
+        """Submit task and wait until done.
+
+        Parameters
+        ----------
+        time_step : float, optional
+            Time in seconds step between status updates.
+        """
+        while self.status() in (JobStatus.RUNNING, JobStatus.NOSTATUS):
+            time.sleep(time_step)

--- a/src/duqtools/models/_job.py
+++ b/src/duqtools/models/_job.py
@@ -5,8 +5,7 @@ from typing import Optional
 
 import click
 
-from ..config import Config
-from ..config import cfg as global_cfg
+from ..config import CFG, Config
 
 logger = logging.getLogger(__name__)
 info, debug = logger.info, logger.debug
@@ -47,10 +46,7 @@ class Job:
     def __init__(self, dir: Path, cfg: Optional[Config] = None):
         self.dir = Path(dir).resolve()
 
-        if cfg is None:
-            cfg = global_cfg
-
-        self.cfg = cfg
+        self.cfg = cfg if cfg is not None else CFG
 
     def __repr__(self):
         run = str(self.dir)

--- a/src/duqtools/models/_locations.py
+++ b/src/duqtools/models/_locations.py
@@ -2,7 +2,7 @@ from os import getenv
 from pathlib import Path
 from typing import Optional
 
-from ..config import cfg
+from ..config import CFG
 from ._run import Run, Runs
 
 
@@ -55,8 +55,8 @@ class Locations:
         Path
         """
 
-        if cfg.create.jruns:  # type: ignore
-            return cfg.create.jruns  # type: ignore
+        if CFG.create.jruns:  # type: ignore
+            return CFG.create.jruns  # type: ignore
         elif getenv('JRUNS'):
             return Path(getenv('JRUNS'))  # type: ignore
         else:

--- a/src/duqtools/models/_run.py
+++ b/src/duqtools/models/_run.py
@@ -48,3 +48,6 @@ class Runs(BaseModel):
 
     def __getitem__(self, index: int):
         return self.__root__[index]
+
+    def __len__(self):
+        return len(self.__root__)

--- a/src/duqtools/operations.py
+++ b/src/duqtools/operations.py
@@ -11,7 +11,7 @@ import click
 from pydantic import Field, validator
 
 from ._logging_utils import duqlog_screen
-from .config import cfg
+from .config import CFG
 from .schema import BaseModel
 
 logger = logging.getLogger(__name__)
@@ -213,7 +213,7 @@ class Operations(deque):
         from tqdm import tqdm
         loginfo(style('Applying Operations', **HEADER_STYLE))  # type: ignore
 
-        if cfg.quiet:
+        if CFG.quiet:
             return self._apply_all()
 
         with tqdm(total=self.n_actions, position=1) as pbar:

--- a/src/duqtools/status.py
+++ b/src/duqtools/status.py
@@ -6,7 +6,7 @@ from typing import Sequence
 
 from jetto_tools import config, template
 
-from .config import cfg
+from .config import CFG
 from .jetto._system import jetto_lookup
 from .models import Job, JobStatus, Locations
 
@@ -193,7 +193,7 @@ def status(*, progress: bool, detailed: bool, **kwargs):
     detailed : bool
         Show detailed progress for every job.
     """
-    debug('Submit config: %s', cfg.submit)
+    debug('Submit config: %s', CFG.submit)
 
     runs = Locations().runs
     jobs = [Job(run.dirname) for run in runs]

--- a/src/duqtools/status.py
+++ b/src/duqtools/status.py
@@ -112,7 +112,7 @@ class Monitor():
         self.job = job
         self.outfile = None
 
-        jetto_template = template.from_directory(job.dir)
+        jetto_template = template.from_directory(job.path)
         jetto_template.lookup.update(jetto_lookup)
         jetto_config = config.RunConfig(jetto_template)
 
@@ -146,7 +146,7 @@ class Monitor():
     def set_status(self):
         status = self.job.status()
 
-        self.pbar.set_description(f'{self.job.dir.name:8s}, {status:12s}')
+        self.pbar.set_description(f'{self.job.path.name:8s}, {status:12s}')
         self.pbar.refresh()
 
         return status

--- a/src/duqtools/submit.py
+++ b/src/duqtools/submit.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Deque, Sequence
 
 from ._logging_utils import duqlog_screen
-from .config import cfg
+from .config import CFG
 from .models import Job, Locations
 from .operations import add_to_op_queue, op_queue
 from .system import get_system
@@ -189,10 +189,10 @@ def submit(*,
     status_filter : list[str]
         Only submit jobs with this status.
     """
-    if not cfg.submit:
+    if not CFG.submit:
         raise SubmitError('Submit field required in config file')
 
-    debug('Submit config: %s', cfg.submit)
+    debug('Submit config: %s', CFG.submit)
 
     if resubmit:
         jobs = get_resubmit_jobs(resubmit)

--- a/src/duqtools/system.py
+++ b/src/duqtools/system.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from .config import Config, cfg
+from .config import CFG, Config
 from .ids import ImasHandle
 from .jetto import JettoSystemV210921, JettoSystemV220922
 from .models import AbstractSystem, Job
@@ -38,12 +38,14 @@ class DummySystem(AbstractSystem):
         pass
 
 
-def get_system():
-    """get_system.
+def get_system(cfg=None):
+    """Get the system to do operations with.
 
-    Get the system to do operations with TODO make it a variable, not a
-    function
+    TODO make it a variable, not a function
     """
+    if cfg is None:
+        cfg = CFG
+
     if (cfg.system in ['jetto', 'jetto-v220922']):
         return JettoSystemV220922
     elif (cfg.system in ['jetto-v210921']):


### PR DESCRIPTION
This PR implements a python api to run `duqtools create` and `duqtools submit` in a Jupyter Notebook or Python environment.

```python
from duqtools.api import create

config = {...}

job, run = create(config)
job.submit()
```

Closes #497