### PR TITLE
Avoid installing typing-extensions==4.6.0 which crashes duqtools on Python 3.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![DOI](https://zenodo.org/badge/492734189.svg)](https://zenodo.org/badge/latestdoi/492734189)
 
 
-![Duqtools banner](./docs/logo.png)
+![Duqtools banner](https://github.com/duqtools/duqtools/raw/main/docs/logo.png)
 
 # Duqtools
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,16 +49,7 @@ theme:
   accent: red
   custom_dir: docs/overrides
   palette:
-    - media: "(prefers-color-scheme: light)"
-      scheme: default
-      toggle:
-        name: Switch to dark mode
-        icon: material/lightbulb
-    - media: "(prefers-color-scheme: dark)"
-      scheme: slate
-      toggle:
-        name: Switch to light mode
-        icon: material/lightbulb-outline
+    accent: indigo
 
 extra_css:
   - stylesheets/extra.css

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,10 +46,12 @@ dependencies = [
     "pydantic-yaml",
     "scipy >= 1.09",
     "tqdm",
+    # 4.6.0  breaks duqtools on python 3.9 using pydantic <=1.10.7
+    # https://github.com/duqtools/duqtools/issues/616
+    "typing-extensions!=4.6.0",
     "xarray",
     "jetto-tools >= 1.8.8",
-    "streamlit == 1.11;python_full_version=='3.9.7'",
-    "streamlit >= 1.12;python_full_version!='3.9.7'",
+    "streamlit >= 1.12"
 ]
 
 [project.urls]


### PR DESCRIPTION
Closes #616