### PR TITLE
Add ceiling and floor option to operator

### DIFF
--- a/docs/templates/template_create.md
+++ b/docs/templates/template_create.md
@@ -175,6 +175,17 @@ With the default `sampler: latin-hypercube`, this means 9 new data files will be
     If you want to copy all time ranges, you can use `path: profiles_1d/*/t_i_ave`. The `*` substring will
     duqtools to apply the operation to all available time slices.
 
+#### Clipping profiles
+
+Values can be clipped to a lower or upper bound by specifying `clip_min` or `clip_max`. This can be helpful to guard against unphysical values. The example below will clip the profile for Zeff at 1 (lower bound):
+
+```yaml
+variable: zeff
+operator: multiply
+values: [0.8, 0.9, 1.0, 1.1, 1.2]
+clip_min: 1
+```
+
 ### Variables
 
 To specify additional variables, you can use the `extra_variables` lookup file. The examples will use the `name` attribute to look up the location of the data. For example, `variable: zeff` will refer to the entry with `name: zeff`.

--- a/src/duqtools/ids/_apply_model.py
+++ b/src/duqtools/ids/_apply_model.py
@@ -73,6 +73,13 @@ def _apply_ids(model: IDSOperation, *,
 
         logger.debug('data range before: %s - %s', data.min(), data.max())
         npfunc(data, value, out=data)
+
+        if model.ceil is not None:
+            np.where(data < model.ceil, data, model.ceil, out=data)
+
+        if model.floor is not None:
+            np.where(data > model.floor, data, model.floor, out=data)
+
         logger.debug('data range after: %s - %s', data.min(), data.max())
 
     if target_in:

--- a/src/duqtools/ids/_apply_model.py
+++ b/src/duqtools/ids/_apply_model.py
@@ -74,11 +74,8 @@ def _apply_ids(model: IDSOperation, *,
         logger.debug('data range before: %s - %s', data.min(), data.max())
         npfunc(data, value, out=data)
 
-        if model.ceil is not None:
-            np.where(data < model.ceil, data, model.ceil, out=data)
-
-        if model.floor is not None:
-            np.where(data > model.floor, data, model.floor, out=data)
+        if model.clip_max is not None or model.clip_min is not None:
+            np.clip(data, a_min=model.clip_min, a_max=model.clip_max, out=data)
 
         logger.debug('data range after: %s - %s', data.min(), data.max())
 

--- a/src/duqtools/schema/_dimensions.py
+++ b/src/duqtools/schema/_dimensions.py
@@ -30,14 +30,16 @@ class OperatorMixin(BaseModel):
         for values > 0.
         """))
 
-    ceil: Optional[float] = Field(None,
-                                  description=f("""
-        If set, this value specifies the ceiling value (upper bound) of the data.
+    clip_min: Optional[float] = Field(None,
+                                      description=f("""
+        If set, clip (limit) data at this value (upper bound).
+        Uses `np.clip`.
         """))
 
-    floor: Optional[float] = Field(None,
-                                   description=f("""
-        If set, this value specifies the floor value (lower bound) of the data.
+    clip_max: Optional[float] = Field(None,
+                                      description=f("""
+        If set, clip (limit) data at this value (lower bound).
+        Uses `np.clip`.
         """))
 
     _upper_suffix: str = '_error_upper'

--- a/src/duqtools/schema/_dimensions.py
+++ b/src/duqtools/schema/_dimensions.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Literal, Union
+from typing import Literal, Optional, Union
 
 from pydantic import Field, validator
 
@@ -28,6 +28,16 @@ class OperatorMixin(BaseModel):
         With asymmetric errors (i.e. both lower/upper error nodes are available),
         scale to the lower error node for values < 0, and to the upper error node
         for values > 0.
+        """))
+
+    ceil: Optional[float] = Field(None,
+                                  description=f("""
+        If set, this value specifies the ceiling value (upper bound) of the data.
+        """))
+
+    floor: Optional[float] = Field(None,
+                                   description=f("""
+        If set, this value specifies the floor value (lower bound) of the data.
         """))
 
     _upper_suffix: str = '_error_upper'

--- a/tests/ids/test_ids_operation.py
+++ b/tests/ids/test_ids_operation.py
@@ -71,6 +71,18 @@ TEST_INPUT = (
         'value': -3.0,
         'scale_to_error': True,
     },
+    {
+        'operator': 'multiply',
+        'variable': get_test_var('data/0/x'),
+        'value': 1.0,
+        'clip_min': 20,
+    },
+    {
+        'operator': 'multiply',
+        'variable': get_test_var('data/0/x'),
+        'value': 1.0,
+        'clip_max': 20,
+    },
 )
 
 TEST_OUTPUT = (
@@ -80,6 +92,8 @@ TEST_OUTPUT = (
     (95, 190, 285),
     (13, 26, 39),
     (4, 8, 12),
+    (20, 20, 30),
+    (10, 20, 20),
 )
 
 


### PR DESCRIPTION
This PR adds optional floor and ceil options to the operator definition.

```yaml
    - variable: zeff
      operator: multiply
      values: [0.8, 0.9, 1.0, 1.1, 1.2]
      clip_min: 1
      clip_max: 10
```

Closes #625 

### Todo
- [x] Update documentation
- [x] Add test