### PR TITLE
Add option to create array submissions script and limit total number of jobs to CLI

### DIFF
--- a/src/duqtools/cli.py
+++ b/src/duqtools/cli.py
@@ -307,31 +307,27 @@ def cli_recreate(**kwargs):
 @click.option('--force',
               is_flag=True,
               help='Re-submit running or completed jobs.')
-@click.option(
-    '--schedule',
-    is_flag=True,
-    help=(
-        'Schedule and submit jobs automatically.'
-        '`max_jobs` defines the total number of jobs running simultaneiously.'
-    ))
+@click.option('--schedule',
+              is_flag=True,
+              help=('Schedule and submit jobs automatically.'))
 @click.option('-j',
               '--max_jobs',
               type=int,
-              help='Maximum number of running jobs.',
+              help='Maximum number of jobs running simultaneously.',
               default=10)
 @click.option(
     '--max_array_size',
     type=int,
     default=100,
     help='Maximum array size for slurm (usually 1001, default = 100).')
-@click.option(
-    '-a',
-    '--array',
-    is_flag=True,
-    help=(
-        'Submit jobs as array. '
-        '`max_jobs` defines the total number of jobs running simultaneiously.'
-    ))
+@click.option('-a', '--array', is_flag=True, help=('Submit jobs as array. '))
+@click.option('--array-script',
+              is_flag=True,
+              help=('Create script to submit jobs as array. '
+                    'Like --array, but does not submit.'))
+@click.option('--limit',
+              type=int,
+              help=('Limits total number of jobs to submit.'))
 @click.option('-r',
               '--resubmit',
               multiple=True,

--- a/src/duqtools/large_scale_validation/cli.py
+++ b/src/duqtools/large_scale_validation/cli.py
@@ -95,17 +95,13 @@ def cli_create(**kwargs):
 @click.option('--force',
               is_flag=True,
               help='Re-submit running or completed jobs.')
-@click.option(
-    '--schedule',
-    is_flag=True,
-    help=(
-        'Schedule and submit jobs automatically. '
-        '`max_jobs` defines the total number of jobs running simultaneiously.'
-    ))
+@click.option('--schedule',
+              is_flag=True,
+              help=('Schedule and submit jobs automatically. '))
 @click.option('-j',
               '--max_jobs',
               type=int,
-              help='Maximum number of running jobs.',
+              help='Maximum number of jobs running simultaneously.',
               default=10)
 @click.option('-s',
               '--status',
@@ -127,14 +123,14 @@ def cli_create(**kwargs):
     help=
     'Only submit jobs for configs where `template_data` matches a handle in this data.csv.'
 )
-@click.option(
-    '-a',
-    '--array',
-    is_flag=True,
-    help=(
-        'Submit jobs as array. '
-        '`max_jobs` defines the total number of jobs running simultaneiously.'
-    ))
+@click.option('-a', '--array', is_flag=True, help=('Submit jobs as array. '))
+@click.option('--array-script',
+              is_flag=True,
+              help=('Create script to submit jobs as array. '
+                    'Like --array, but does not submit.'))
+@click.option('--limit',
+              type=int,
+              help=('Limits total number of jobs to submit.'))
 @click.option(
     '--max_array_size',
     type=int,

--- a/src/duqtools/models/_system.py
+++ b/src/duqtools/models/_system.py
@@ -165,11 +165,12 @@ class AbstractSystem(ABC, BaseModel):
         *,
         max_jobs: int = 10,
         max_array_size: int = 100,
+        create_only: bool = False,
         **kwargs,
     ):
-        """submit_array method used for submitting the jobs in an array
-        fashion, its perfectly fine to just throw an error if the system does
-        not support it.
+        """Submit method used for submitting the jobs in an array fashion, its
+        perfectly fine to just throw an error if the system does not support
+        it.
 
         Parameters
         ----------
@@ -179,7 +180,9 @@ class AbstractSystem(ABC, BaseModel):
             max_jobs
         max_array_size : int
             max_array_size
+        create_only : bool
+            If true, create array script, but do not submit
         kwargs :
-            optional arguments
+            Optional arguments
         """
         pass


### PR DESCRIPTION
This PR adds a new option to create the array script, but not submit it:

```
duqtools submit --array-script
duqduq submit --array-script
```

It also adds an option to limit the maximum number of jobs:

```
duqtools submit --array-script --limit 100
duqduq submit --array-script --limit 100
```

`max_jobs` controls the number of parallel jobs. For `duqtools submit`, this means that `--max_jobs` and `--limit` effectively do the same thing.

Closes #643