### PR TITLE
Update code to support pydantic V2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,6 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 ---
-exclude: |
-  (?x)
-  \.vol
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
@@ -43,7 +40,7 @@ repos:
     hooks:
       - id: mypy
         additional_dependencies:
-          - "pydantic<2.0.0"
+          - "pydantic >= 2.0.0"
   - repo: https://github.com/nbQA-dev/nbQA
     rev: 1.7.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,16 +27,16 @@ repos:
         additional_dependencies:
           - toml
   - repo: https://github.com/myint/docformatter
-    rev: v1.7.2
+    rev: v1.7.5
     hooks:
       - id: docformatter
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.274
+    rev: v0.0.287
     hooks:
       - id: ruff
         args: [--fix]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.4.1
+    rev: v1.5.1
     hooks:
       - id: mypy
         additional_dependencies:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,13 +42,11 @@ dependencies = [
     "importlib_resources;python_version<'3.10'",
     "numpy",
     "pandas",
-    "pydantic !=1.10.3, !=1.10.4, !=1.10.5, <2.0.0",
+    "pydantic >= 2.0",
     "pydantic-yaml >= 1.0",
     "scipy >= 1.09",
     "tqdm",
-    # 4.6.0  breaks duqtools on python 3.9 using pydantic <=1.10.7
-    # https://github.com/duqtools/duqtools/issues/616
-    "typing-extensions!=4.6.0",
+    "typing-extensions",
     "xarray",
     "jetto-tools >= 1.8.8",
     "streamlit >= 1.18",

--- a/src/duqtools/__init__.py
+++ b/src/duqtools/__init__.py
@@ -3,9 +3,6 @@ def fix_dependencies():
     import __main__
     __main__.__requires__ = [
         'jetto_tools>=1.8.8',
-        'pydantic!=1.10.3',
-        'pydantic!=1.10.4',
-        'pydantic!=1.10.5',
         'scipy>=1.09',
         'jinja2>=3.0.0',
     ]

--- a/src/duqtools/models/_run.py
+++ b/src/duqtools/models/_run.py
@@ -1,23 +1,22 @@
 from pathlib import Path
 from typing import Optional, Union
 
-from pydantic import Field, root_validator
+from pydantic import Field, model_validator
 
 from ..ids import ImasHandle
-from ..schema import BaseModel, IDSOperation, ImasBaseModel, JettoOperation
+from ..schema import BaseModel, IDSOperation, ImasBaseModel, JettoOperation, RootModel
 
 
 class Run(BaseModel):
     dirname: Path = Field(description='Directory of run')
     shortname: Optional[Path] = Field(
-        description='Short name (`dirname.name`)')
+        None, description='Short name (`dirname.name`)')
     data_in: Optional[ImasBaseModel] = Field(None)
     data_out: Optional[ImasBaseModel] = Field(None)
-    operations: Optional[list[Union[IDSOperation, JettoOperation,
-                                    list[Union[IDSOperation,
-                                               JettoOperation]]]]]
+    operations: Optional[list[Union[IDSOperation, JettoOperation, list[Union[
+        IDSOperation, JettoOperation]]]]] = Field(None)
 
-    @root_validator()
+    @model_validator(mode='before')
     def shortname_compat(cls, root):
         # Compatibility with old runs.yaml
         if 'shortname' not in root and 'dirname' in root:
@@ -40,14 +39,14 @@ class Run(BaseModel):
         return self.shortname == 'base'
 
 
-class Runs(BaseModel):
-    __root__: list[Run] = []
+class Runs(RootModel):
+    root: list[Run] = []
 
     def __iter__(self):
-        yield from self.__root__
+        yield from self.root
 
     def __getitem__(self, index: int):
-        return self.__root__[index]
+        return self.root[index]
 
     def __len__(self):
-        return len(self.__root__)
+        return len(self.root)

--- a/src/duqtools/operations.py
+++ b/src/duqtools/operations.py
@@ -35,10 +35,13 @@ logwarning = duqlog_screen.warning
 style = click.style
 
 
-class LongDescriptionMixin:
-    description: str
-    extra_description: Optional[str]
-    style: dict
+class LongDescription(BaseModel):
+    description: str = Field(
+        description='description of the operation to be done')
+    extra_description: Optional[str] = Field(None,
+                                             description='Extra description')
+    style: dict[str, Any] = Field(OP_STYLE,
+                                  description='Styling for op description')
 
     @property
     def long_description(self) -> str:
@@ -50,13 +53,9 @@ class LongDescriptionMixin:
         return description
 
 
-class Warning(LongDescriptionMixin):
+class Warning(LongDescription):
     """Warning item for screen log."""
-    style = NO_OP_STYLE
-
-    def __init__(self, description: str, extra_description: str):
-        self.description = description
-        self.extra_description = extra_description
+    style: dict[str, Any] = NO_OP_STYLE
 
     def __hash__(self):
         return hash((self.description, self.extra_description))
@@ -65,27 +64,24 @@ class Warning(LongDescriptionMixin):
         return hash(self) == hash(other)
 
 
-class Operation(LongDescriptionMixin, BaseModel):
+class Operation(LongDescription):
     """Operation, simple class which has a callable action.
 
-    Usually not called directly but used through Operations. has the
-    following members:
+    Usually not called directly but used through Operations.
     """
-
     quiet: bool = Field(False,
                         description='print out this operation to the screen')
-    description: str = Field(
-        description='description of the operation to be done')
+
     action: Optional[Callable] = Field(
+        None,
         description='a function which can be executed when we '
         'decide to apply this operation')
-    extra_description: Optional[str] = Field(description='Extra description')
+
     args: Optional[Sequence] = Field(
         None,
         description='positional arguments that have to be '
         'passed to the action')
-    style: dict[str, Any] = Field(OP_STYLE,
-                                  description='Styling for op description')
+
     kwargs: Optional[dict] = Field(
         None,
         description='keyword arguments that will be '

--- a/src/duqtools/schema/__init__.py
+++ b/src/duqtools/schema/__init__.py
@@ -1,4 +1,4 @@
-from ._basemodel import BaseModel
+from ._basemodel import BaseModel, RootModel
 from ._dimensions import IDSOperation, IDSOperationDim, JettoOperation, OperationDim
 from ._imas import ImasBaseModel
 from ._jetto import JettoField, JettoVar, JsetField, NamelistField
@@ -15,6 +15,7 @@ from ._variable import IDS2JettoVariableModel, IDSVariableModel, JettoVariableMo
 __all__ = [
     'ARange',
     'BaseModel',
+    'RootModel',
     'IDSOperation',
     'IDSOperationDim',
     'IDSVariableModel',

--- a/src/duqtools/schema/_basemodel.py
+++ b/src/duqtools/schema/_basemodel.py
@@ -1,9 +1,13 @@
 from pydantic import BaseModel as PydanticBaseModel
-from pydantic import Extra
+from pydantic import ConfigDict, Extra
+from pydantic import RootModel as PydanticRootModel
 
 
 class BaseModel(PydanticBaseModel):
     """Base model."""
 
-    class Config:
-        extra = Extra.forbid
+    model_config = ConfigDict(extra=Extra.forbid)
+
+
+class RootModel(PydanticRootModel):
+    """Root model."""

--- a/src/duqtools/schema/_systems.py
+++ b/src/duqtools/schema/_systems.py
@@ -129,8 +129,10 @@ class JettoSystemModel(SystemModel):
             running status.
             """))
 
-    jruns: Optional[DirectoryPath] = Field(description=f(
-        """`jruns` defines the the root directory where all simulations are
+    jruns: Optional[DirectoryPath] = Field(
+        None,
+        description=f(
+            """`jruns` defines the the root directory where all simulations are
         run for the jetto system. Because the jetto system works with relative
         directories from some root directory.
 

--- a/src/duqtools/schema/_variable.py
+++ b/src/duqtools/schema/_variable.py
@@ -18,7 +18,9 @@ class JettoVariableModel(BaseModel):
         Name of the variable.
         Used for the lookup table to find actual fields.
         """))
-    lookup: Optional[JettoVar] = Field(description=f("""
+
+    lookup: Optional[JettoVar] = Field(None,
+                                       description=f("""
     Description of the fields that have to be updated for a Jetto Variable
     """))
 

--- a/src/duqtools/schema/_variable.py
+++ b/src/duqtools/schema/_variable.py
@@ -85,6 +85,7 @@ class IDS2JettoVariableModel(BaseModel):
         Search these variables in the given order until a match with the conditions
         defined below is found.
     """))
-    default: Optional[float] = Field(description=f("""
+    default: Optional[float] = Field(None,
+                                     description=f("""
         Default value if no match is found. Set to None to raise an exeption instead."""
                                                    ))

--- a/src/duqtools/schema/cli.py
+++ b/src/duqtools/schema/cli.py
@@ -16,8 +16,10 @@ from .variables import VariableConfigModel
 class CreateConfigModel(BaseModel):
     """The options of the `create` subcommand are stored in the `create` key in
     the config."""
-    runs_dir: Optional[Path] = Field(description=f(
-        """Relative location from the workspace, which specifies the folder where to
+    runs_dir: Optional[Path] = Field(
+        None,
+        description=
+        f("""Relative location from the workspace, which specifies the folder where to
         store all the created runs.
 
         This defaults to `workspace/duqtools_experiment_x`
@@ -32,7 +34,8 @@ class CreateConfigModel(BaseModel):
         the UQ runs.
         """))
 
-    template_data: Optional[ImasBaseModel] = Field(description=f("""
+    template_data: Optional[ImasBaseModel] = Field(None,
+                                                   description=f("""
         Specify the location of the template data to modify. This overrides the
         location of the data specified in settings file in the template
         directory.
@@ -73,7 +76,8 @@ class CreateConfigModel(BaseModel):
         this hypercube can be efficiently sampled. This paramater is optional.
         """))
 
-    data: Optional[DataLocation] = Field(description=f("""
+    data: Optional[DataLocation] = Field(None,
+                                         description=f("""
         Required for system `jetto-v210921`, ignored for other systems.
 
         Where to store the in/output IDS data.
@@ -94,11 +98,12 @@ class ConfigModel(BaseModel):
         'Create a tag for the runs to identify them in slurm or `data.csv`')
 
     create: Optional[CreateConfigModel] = Field(
+        None,
         description=
         'Configuration for the create subcommand. See model for more info.')
 
     extra_variables: Optional[VariableConfigModel] = Field(
-        description='Specify extra variables for this run.')
+        None, description='Specify extra variables for this run.')
 
     system: Union[DummySystemModel, Ets6SystemModel, JettoSystemModel] = Field(
         JettoSystemModel(),

--- a/src/duqtools/schema/variables.py
+++ b/src/duqtools/schema/variables.py
@@ -1,18 +1,18 @@
 from typing import Union
 
-from ._basemodel import BaseModel
+from ._basemodel import RootModel
 from ._variable import IDS2JettoVariableModel, IDSVariableModel, JettoVariableModel
 
 
-class VariableConfigModel(BaseModel):
-    __root__: list[Union[JettoVariableModel, IDSVariableModel,
-                         IDS2JettoVariableModel]]
+class VariableConfigModel(RootModel):
+    root: list[Union[JettoVariableModel, IDSVariableModel,
+                     IDS2JettoVariableModel]]
 
     def __iter__(self):
-        yield from self.__root__
+        yield from self.root
 
     def __getitem__(self, index: int):
-        return self.__root__[index]
+        return self.root[index]
 
     def to_variable_dict(self) -> dict:
         """Return dict of variables."""


### PR DESCRIPTION
This PR updates the code to work with Pydantic V2:

All changes fall in these categories:

- https://docs.pydantic.dev/2.3/migration/#validator-and-root_validator-are-deprecated
- https://docs.pydantic.dev/2.3/migration/#required-optional-and-nullable-fields
- https://docs.pydantic.dev/2.3/usage/models/#rootmodel-and-custom-root-types