### PR TITLE
Add option to run duqtools without a system

### DIFF
--- a/docs/gendocs.py
+++ b/docs/gendocs.py
@@ -27,7 +27,7 @@ from duqtools.schema import (
 from duqtools.schema._jetto import JsetField, NamelistField
 from duqtools.schema.cli import ConfigModel, CreateConfigModel
 from duqtools.schema.data_location import DataLocation
-from duqtools.system import DummySystem
+from duqtools.system import NoSystem
 
 this_dir = Path(__file__).parent
 sys.path.append(str(this_dir))
@@ -41,7 +41,7 @@ objects = {
     ConfigModel,
     CreateConfigModel,
     DataLocation,
-    DummySystem,
+    NoSystem,
     IDSOperationDim,
     IDSVariableModel,
     ImasBaseModel,

--- a/docs/templates/template_index.md
+++ b/docs/templates/template_index.md
@@ -49,9 +49,9 @@ system:
 
 {{ schema_Ets6System['description'] }}
 
-### dummy
+### No system
 
-{{ schema_DummySystem['description'] }}
+{{ schema_NoSystem['description'] }}
 
 ## Extra variables
 

--- a/src/duqtools/create.py
+++ b/src/duqtools/create.py
@@ -49,6 +49,8 @@ class CreateManager:
         template_data = self.options.template_data
 
         if not template_data:
+            if not self.template_drc:
+                raise ValueError('Missing `create.template`')
             source = self.system.imas_from_path(self.template_drc)
         else:
             source = ImasHandle.model_validate(template_data,
@@ -231,18 +233,18 @@ class CreateManager:
         self.source.copy_data_to(
             ImasHandle.model_validate(model.data_in, from_attributes=True))
 
-        self.system.copy_from_template(self.template_drc, model.dirname)
+        if self.template_drc:
+            self.system.copy_from_template(self.template_drc, model.dirname)
 
         self.apply_operations(model.data_in, model.dirname, model.operations)
 
         self.system.write_batchfile(model.dirname)
 
         if model.data_in and model.data_out:
-            self.system.update_imas_locations(
-                run=model.dirname,
-                inp=model.data_in,
-                out=model.data_out,
-                cfg_filename=self.template_drc.name)
+            self.system.update_imas_locations(run=model.dirname,
+                                              inp=model.data_in,
+                                              out=model.data_out,
+                                              template_drc=self.template_drc)
         else:
             raise Exception(
                 'data not present in model, this should not happen')

--- a/src/duqtools/ets/_system.py
+++ b/src/duqtools/ets/_system.py
@@ -28,7 +28,13 @@ BATCH_TEMPLATE = '\n'.join([
 
 
 class Ets6System(AbstractSystem, Ets6SystemModel):
-    """System that can be used to create runs for ets."""
+    """System that can be used to create runs for ets.
+
+    ```yaml title="duqtools.yaml"
+    system:
+      name: 'ets6'
+    ```
+    """
 
     def get_runs_dir(self) -> Path:
         runs_dir = self.cfg.create.runs_dir  # type: ignore

--- a/src/duqtools/ets/_system.py
+++ b/src/duqtools/ets/_system.py
@@ -134,9 +134,10 @@ class Ets6System(AbstractSystem, Ets6SystemModel):
 
     @add_to_op_queue('Updating imas locations of', '{run}', quiet=True)
     def update_imas_locations(self, run: Path, inp: ImasHandle,
-                              out: ImasHandle, cfg_filename: Path):
+                              out: ImasHandle, template_drc: Path):
         #raise NotImplementedError('update_imas_location')
         new_input = []
+        cfg_filename = template_drc.name
         with open(run / cfg_filename) as f:
             for line in f.readlines():
                 if line.startswith('START.output_run'):

--- a/src/duqtools/jetto/_system.py
+++ b/src/duqtools/jetto/_system.py
@@ -13,6 +13,7 @@ from jetto_tools import job as jetto_job
 from jetto_tools.template import _EXTRA_FILE_REGEXES
 
 from ..ids import ImasHandle
+from ..jintrac import V210921Mixin, V220922Mixin
 from ..models import AbstractSystem, Job
 from ..operations import add_to_op_queue
 from ..schema import JettoSystemModel, JettoVar
@@ -334,7 +335,7 @@ class BaseJettoSystem(AbstractSystem, JettoSystemModel):
         jetto_config.export(run)  # Just overwrite the poor files
 
 
-class JettoSystemV210921(BaseJettoSystem):
+class JettoSystemV210921(V210921Mixin, BaseJettoSystem):
     """System that can be used to create runs for jetto.
 
     The backend that is  assumed is jetto-v210921.
@@ -349,40 +350,8 @@ class JettoSystemV210921(BaseJettoSystem):
     ```
     """
 
-    def get_data_in_handle(
-        self,
-        *,
-        dirname: Path,
-        source: ImasHandle,
-        seq_number: int,
-        options,
-    ):
-        """Get handle for data input."""
-        return ImasHandle(
-            user=options.user,
-            db=options.imasdb,
-            shot=source.shot,
-            run=options.run_in_start_at + seq_number,
-        )
 
-    def get_data_out_handle(
-        self,
-        *,
-        dirname: Path,
-        source: ImasHandle,
-        seq_number: int,
-        options,
-    ):
-        """Get handle for data output."""
-        return ImasHandle(
-            user=options.user,
-            db=options.imasdb,
-            shot=source.shot,
-            run=options.run_out_start_at + seq_number,
-        )
-
-
-class JettoSystemV220922(BaseJettoSystem):
+class JettoSystemV220922(V220922Mixin, BaseJettoSystem):
     """System that can be used to create runs for jetto.
 
     The backend that is  assumed is jetto-v220922. The most important
@@ -398,46 +367,6 @@ class JettoSystemV220922(BaseJettoSystem):
       submit_system: docker
     ```
     """
-
-    def get_data_in_handle(
-        self,
-        *,
-        dirname: Path,
-        source: ImasHandle,
-        seq_number: int,
-        options,
-    ):
-        relative_location: Optional[str] = str(
-            os.path.relpath((dirname / 'imasdb').resolve()))
-        if relative_location:
-            if relative_location.startswith('..'):
-                relative_location = None
-        """Get handle for data input."""
-        return ImasHandle(user=str((dirname / 'imasdb').resolve()),
-                          db=source.db,
-                          shot=source.shot,
-                          run=1,
-                          relative_location=relative_location)
-
-    def get_data_out_handle(
-        self,
-        *,
-        dirname: Path,
-        source: ImasHandle,
-        seq_number: int,
-        options,
-    ):
-        relative_location: Optional[str] = str(
-            os.path.relpath((dirname / 'imasdb').resolve()))
-        if relative_location:
-            if relative_location.startswith('..'):
-                relative_location = None
-        """Get handle for data output."""
-        return ImasHandle(user=str((dirname / 'imasdb').resolve()),
-                          db=source.db,
-                          shot=source.shot,
-                          run=2,
-                          relative_location=relative_location)
 
 
 JettoSystem = JettoSystemV220922

--- a/src/duqtools/jetto/_system.py
+++ b/src/duqtools/jetto/_system.py
@@ -335,7 +335,7 @@ class BaseJettoSystem(AbstractSystem, JettoSystemModel):
         jetto_config.export(run)  # Just overwrite the poor files
 
 
-class JettoSystemV210921(V210921Mixin, BaseJettoSystem):
+class JettoSystemV210921(V210921Mixin, BaseJettoSystem):  # type: ignore
     """System that can be used to create runs for jetto.
 
     The backend that is  assumed is jetto-v210921.
@@ -351,7 +351,7 @@ class JettoSystemV210921(V210921Mixin, BaseJettoSystem):
     """
 
 
-class JettoSystemV220922(V220922Mixin, BaseJettoSystem):
+class JettoSystemV220922(V220922Mixin, BaseJettoSystem):  # type: ignore
     """System that can be used to create runs for jetto.
 
     The backend that is  assumed is jetto-v220922. The most important

--- a/src/duqtools/jintrac.py
+++ b/src/duqtools/jintrac.py
@@ -1,0 +1,85 @@
+import os
+from pathlib import Path
+from typing import Optional
+
+from duqtools.ids import ImasHandle
+
+
+class V210921Mixin:
+    """Data handler Mixin for v220922."""
+
+    def get_data_in_handle(
+        self,
+        *,
+        dirname: Path,
+        source: ImasHandle,
+        seq_number: int,
+        options,
+    ):
+        """Get handle for data input."""
+        return ImasHandle(
+            user=options.user,
+            db=options.imasdb,
+            shot=source.shot,
+            run=options.run_in_start_at + seq_number,
+        )
+
+    def get_data_out_handle(
+        self,
+        *,
+        dirname: Path,
+        source: ImasHandle,
+        seq_number: int,
+        options,
+    ):
+        """Get handle for data output."""
+        return ImasHandle(
+            user=options.user,
+            db=options.imasdb,
+            shot=source.shot,
+            run=options.run_out_start_at + seq_number,
+        )
+
+
+class V220922Mixin:
+    """Data handler Mixin for v220922."""
+
+    def get_data_in_handle(
+        self,
+        *,
+        dirname: Path,
+        source: ImasHandle,
+        seq_number: int,
+        options,
+    ):
+        """Get handle for data input."""
+        relative_location: Optional[str] = str(
+            os.path.relpath((dirname / 'imasdb').resolve()))
+        if relative_location:
+            if relative_location.startswith('..'):
+                relative_location = None
+        return ImasHandle(user=str((dirname / 'imasdb').resolve()),
+                          db=source.db,
+                          shot=source.shot,
+                          run=1,
+                          relative_location=relative_location)
+
+    def get_data_out_handle(
+        self,
+        *,
+        dirname: Path,
+        source: ImasHandle,
+        seq_number: int,
+        options,
+    ):
+        """Get handle for data output."""
+        relative_location: Optional[str] = str(
+            os.path.relpath((dirname / 'imasdb').resolve()))
+        if relative_location:
+            if relative_location.startswith('..'):
+                relative_location = None
+        return ImasHandle(user=str((dirname / 'imasdb').resolve()),
+                          db=source.db,
+                          shot=source.shot,
+                          run=2,
+                          relative_location=relative_location)

--- a/src/duqtools/models/_locations.py
+++ b/src/duqtools/models/_locations.py
@@ -50,4 +50,4 @@ class Locations:
         with open(runs_yaml) as f:
             model = parse_yaml_raw_as(Runs, f)
 
-        return model
+        return model.root

--- a/src/duqtools/models/_system.py
+++ b/src/duqtools/models/_system.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Sequence
 
 from ..config import Config
-from ..schema import ImasBaseModel
+from ..schema import BaseModel, ImasBaseModel
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class AbstractSystem(ABC):
+class AbstractSystem(ABC, BaseModel):
 
     cfg: Config
 

--- a/src/duqtools/models/_system.py
+++ b/src/duqtools/models/_system.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Sequence
 
 from ..config import Config
-from ..schema import BaseModel, ImasBaseModel
+from ..schema import ImasBaseModel
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class AbstractSystem(ABC, BaseModel):
+class AbstractSystem(ABC):
 
     cfg: Config
 

--- a/src/duqtools/schema/__init__.py
+++ b/src/duqtools/schema/__init__.py
@@ -7,6 +7,7 @@ from ._systems import (
     DummySystemModel,
     Ets6SystemModel,
     JettoSystemModel,
+    NoSystemModel,
     StatusConfigModel,
     SubmitConfigModel,
 )
@@ -33,5 +34,6 @@ __all__ = [
     'SubmitConfigModel',
     'JettoSystemModel',
     'DummySystemModel',
+    'NoSystemModel',
     'Ets6SystemModel',
 ]

--- a/src/duqtools/schema/__init__.py
+++ b/src/duqtools/schema/__init__.py
@@ -4,7 +4,6 @@ from ._imas import ImasBaseModel
 from ._jetto import JettoField, JettoVar, JsetField, NamelistField
 from ._ranges import ARange, LinSpace
 from ._systems import (
-    DummySystemModel,
     Ets6SystemModel,
     JettoSystemModel,
     NoSystemModel,
@@ -33,7 +32,6 @@ __all__ = [
     'StatusConfigModel',
     'SubmitConfigModel',
     'JettoSystemModel',
-    'DummySystemModel',
     'NoSystemModel',
     'Ets6SystemModel',
 ]

--- a/src/duqtools/schema/_systems.py
+++ b/src/duqtools/schema/_systems.py
@@ -60,7 +60,7 @@ class SystemModel(StatusConfigModel, SubmitConfigModel):
 
 
 class NoSystemModel(SystemModel):
-    name: Literal[None] = Field(None, description='No system.')
+    name: Literal[None, 'nosystem'] = Field(None, description='No system.')
 
 
 class Ets6SystemModel(SystemModel):

--- a/src/duqtools/schema/_systems.py
+++ b/src/duqtools/schema/_systems.py
@@ -63,12 +63,6 @@ class NoSystemModel(SystemModel):
     name: Literal[None] = Field(None, description='No system.')
 
 
-class DummySystemModel(SystemModel):
-    name: Literal['dummy'] = 'dummy'
-    submit_script_name: str = 'true'
-    submit_command: str = 'true'
-
-
 class Ets6SystemModel(SystemModel):
     name: Literal['ets6'] = Field(
         'ets6', description='Backend system to use. Set by ConfigModel.')

--- a/src/duqtools/schema/_systems.py
+++ b/src/duqtools/schema/_systems.py
@@ -59,6 +59,16 @@ class SystemModel(StatusConfigModel, SubmitConfigModel):
     pass
 
 
+class NoSystemModel(SystemModel):
+    name: Literal[None] = Field(None, description='No system.')
+
+
+class DummySystemModel(SystemModel):
+    name: Literal['dummy'] = 'dummy'
+    submit_script_name: str = 'true'
+    submit_command: str = 'true'
+
+
 class Ets6SystemModel(SystemModel):
     name: Literal['ets6'] = Field(
         'ets6', description='Backend system to use. Set by ConfigModel.')
@@ -72,12 +82,6 @@ class Ets6SystemModel(SystemModel):
     ets_xml: str = Field(
         '$ITMWORK/ETS6.xml',
         description='ETS6.XML file to use, can include for example `$ITMWORK`')
-
-
-class DummySystemModel(SystemModel):
-    name: Literal['dummy'] = 'dummy'
-    submit_script_name: str = 'true'
-    submit_command: str = 'true'
 
 
 class JettoSystemModel(SystemModel):

--- a/src/duqtools/schema/cli.py
+++ b/src/duqtools/schema/cli.py
@@ -7,7 +7,7 @@ from ._basemodel import BaseModel
 from ._description_helpers import formatter as f
 from ._dimensions import CoupledDim, Operation, OperationDim
 from ._imas import ImasBaseModel
-from ._systems import DummySystemModel, Ets6SystemModel, JettoSystemModel, NoSystemModel
+from ._systems import Ets6SystemModel, JettoSystemModel, NoSystemModel
 from .data_location import DataLocation
 from .matrix_samplers import CartesianProduct, HaltonSampler, LHSSampler, SobolSampler
 from .variables import VariableConfigModel
@@ -106,11 +106,10 @@ class ConfigModel(BaseModel):
     extra_variables: Optional[VariableConfigModel] = Field(
         None, description='Specify extra variables for this run.')
 
-    system: Union[NoSystemModel, DummySystemModel, Ets6SystemModel,
-                  JettoSystemModel] = Field(
-                      NoSystemModel(),
-                      description='Options specific to the system used',
-                      discriminator='name')
+    system: Union[NoSystemModel, Ets6SystemModel, JettoSystemModel] = Field(
+        NoSystemModel(),
+        description='Options specific to the system used',
+        discriminator='name')
 
     quiet: bool = Field(
         False,

--- a/src/duqtools/schema/cli.py
+++ b/src/duqtools/schema/cli.py
@@ -7,7 +7,7 @@ from ._basemodel import BaseModel
 from ._description_helpers import formatter as f
 from ._dimensions import CoupledDim, Operation, OperationDim
 from ._imas import ImasBaseModel
-from ._systems import DummySystemModel, Ets6SystemModel, JettoSystemModel
+from ._systems import DummySystemModel, Ets6SystemModel, JettoSystemModel, NoSystemModel
 from .data_location import DataLocation
 from .matrix_samplers import CartesianProduct, HaltonSampler, LHSSampler, SobolSampler
 from .variables import VariableConfigModel
@@ -25,13 +25,14 @@ class CreateConfigModel(BaseModel):
         This defaults to `workspace/duqtools_experiment_x`
         where `x` is a not yet existing integer."""))
 
-    template: Path = Field(description=f("""
+    template: Optional[Path] = Field(None,
+                                     description=f("""
         Template directory to modify. Duqtools copies and updates the settings
         required for the specified system from this directory. This can be a
         directory with a finished run, or one just stored by JAMS (but not yet
         started). By default, duqtools extracts the input IMAS database entry
         from the settings file (e.g. jetto.in) to find the data to modify for
-        the UQ runs.
+        the UQ runs. Defaults to None.
         """))
 
     template_data: Optional[ImasBaseModel] = Field(None,
@@ -105,10 +106,11 @@ class ConfigModel(BaseModel):
     extra_variables: Optional[VariableConfigModel] = Field(
         None, description='Specify extra variables for this run.')
 
-    system: Union[DummySystemModel, Ets6SystemModel, JettoSystemModel] = Field(
-        JettoSystemModel(),
-        description='Options specific to the system used',
-        discriminator='name')
+    system: Union[NoSystemModel, DummySystemModel, Ets6SystemModel,
+                  JettoSystemModel] = Field(
+                      NoSystemModel(),
+                      description='Options specific to the system used',
+                      discriminator='name')
 
     quiet: bool = Field(
         False,

--- a/src/duqtools/system.py
+++ b/src/duqtools/system.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from typing import Any
 
@@ -5,8 +6,9 @@ from .config import Config
 from .ets import Ets6System
 from .ids import ImasHandle
 from .jetto import JettoSystemV210921, JettoSystemV220922
+from .jintrac import V220922Mixin
 from .models import AbstractSystem, Job
-from .schema import DummySystemModel
+from .schema import DummySystemModel, NoSystemModel
 
 
 class DummySystem(AbstractSystem, DummySystemModel):
@@ -41,6 +43,65 @@ class DummySystem(AbstractSystem, DummySystemModel):
         pass
 
 
+class NoSystem(NoSystemModel, V220922Mixin, AbstractSystem):
+    """The no system does nothing."""
+
+    @property
+    def jruns_path(self) -> Path:
+        """Return the Path specified in the `$JRUNS` environment variable, or,
+        if `$JRUNS` does not exists, return the current directory `./`.
+
+        Returns
+        -------
+        Path
+        """
+        if jruns_env := os.getenv('JRUNS'):
+            return Path(jruns_env)
+        else:
+            return Path()
+
+    def get_runs_dir(self) -> Path:
+        path = self.jruns_path
+        runs_dir = self.cfg.create.runs_dir
+
+        if runs_dir:
+            return path / runs_dir
+
+        abs_cwd = str(Path.cwd().resolve())
+        abs_jruns = str(path.resolve())
+
+        # Check if jruns is parent dir of current dir
+        if abs_cwd.startswith(abs_jruns):
+            return path
+
+        count = 0
+        while True:  # find the next free folder
+            dirname = f'duqtools_data_{count:04d}'
+            if not (path / dirname).exists():
+                break
+            count = count + 1
+
+        return path / dirname
+
+    def write_batchfile(*args, **kwargs):
+        pass
+
+    def copy_from_template(*args, **kwargs):
+        pass
+
+    def update_imas_locations(*args, **kwargs):
+        pass
+
+    def submit_array(*args, **kwargs):
+        pass
+
+    def submit_job(*args, **kwargs):
+        pass
+
+    def imas_from_path(*args, **kwargs):
+        pass
+
+
 def get_system(cfg: Config) -> AbstractSystem:
     """Get the system to do operations with."""
     System: Any = None  # Shut up mypy
@@ -53,6 +114,8 @@ def get_system(cfg: Config) -> AbstractSystem:
         System = Ets6System
     elif (cfg.system.name == 'dummy'):
         System = DummySystem
+    elif (cfg.system.name is None):
+        System = NoSystem
     else:
         raise NotImplementedError(
             f'system {cfg.system.name} is not implemented')

--- a/src/duqtools/system.py
+++ b/src/duqtools/system.py
@@ -83,13 +83,13 @@ def get_system(cfg: Config) -> AbstractSystem:
     """Get the system to do operations with."""
     System: Any = None  # Shut up mypy
 
-    if (cfg.system.name in ['jetto', 'jetto-v220922', 'jetto-v230123']):
+    if (cfg.system.name in ('jetto', 'jetto-v220922', 'jetto-v230123')):
         System = JettoSystemV220922
-    elif (cfg.system.name in ['jetto-v210921']):
+    elif (cfg.system.name == 'jetto-v210921'):
         System = JettoSystemV210921
     elif (cfg.system.name == 'ets6'):
         System = Ets6System
-    elif (cfg.system.name is None):
+    elif (cfg.system.name in (None, 'nosystem')):
         System = NoSystem
     else:
         raise NotImplementedError(

--- a/src/duqtools/system.py
+++ b/src/duqtools/system.py
@@ -4,43 +4,10 @@ from typing import Any
 
 from .config import Config
 from .ets import Ets6System
-from .ids import ImasHandle
 from .jetto import JettoSystemV210921, JettoSystemV220922
 from .jintrac import V220922Mixin
-from .models import AbstractSystem, Job
-from .schema import DummySystemModel, NoSystemModel
-
-
-class DummySystem(AbstractSystem, DummySystemModel):
-    """This is a dummy system that implements the basic interfaces.
-
-    It exists for testing purposes in absence of actual modelling
-    software.
-    """
-
-    @staticmethod
-    def get_runs_dir() -> Path:
-        return Path()
-
-    @staticmethod
-    def write_batchfile(run_dir: Path):
-        pass
-
-    @staticmethod
-    def submit_job(job: Job):
-        pass
-
-    @staticmethod
-    def copy_from_template(source_drc: Path, target_drc: Path):
-        pass
-
-    @staticmethod
-    def imas_from_path(template_drc: Path):
-        return ImasHandle(db='', shot='-1', run='-1')
-
-    @staticmethod
-    def update_imas_locations(run: Path, inp, out, **kwargs):
-        pass
+from .models import AbstractSystem
+from .schema import NoSystemModel
 
 
 class NoSystem(NoSystemModel, V220922Mixin, AbstractSystem):
@@ -112,8 +79,6 @@ def get_system(cfg: Config) -> AbstractSystem:
         System = JettoSystemV210921
     elif (cfg.system.name == 'ets6'):
         System = Ets6System
-    elif (cfg.system.name == 'dummy'):
-        System = DummySystem
     elif (cfg.system.name is None):
         System = NoSystem
     else:

--- a/src/duqtools/system.py
+++ b/src/duqtools/system.py
@@ -11,7 +11,17 @@ from .schema import NoSystemModel
 
 
 class NoSystem(NoSystemModel, V220922Mixin, AbstractSystem):
-    """The no system does nothing."""
+    """This system is intended for workflows that need to apply some operations
+    or sampling of the data without any system like Jetto or ETS in mind.
+
+    With this system, you won't have to specify `create.template`. Only
+    `create.template_data` is required.
+
+    ```yaml title="duqtools.yaml"
+    system:
+      name: 'nosystem'  # or `name: None`
+    ```
+    """
 
     @property
     def jruns_path(self) -> Path:


### PR DESCRIPTION
This PR adds a 'NoSystem' system that can be used to just generate data. It does not require or copy over a template.

```yaml
system:
  name: null
```

Closes #637 

### Todo

- [x] Update docs
- [x] Remove dummy system (I don't think it's in use anywhere)
- [x] Fix mypy