### PR TITLE
Update pattern to allow parsing localdb strings

### DIFF
--- a/src/duqtools/ids/_handle.py
+++ b/src/duqtools/ids/_handle.py
@@ -39,7 +39,7 @@ SUFFIXES = (
 )
 
 IMAS_PATTERN = re.compile(
-    r'^((?P<user>\w+)/)?(?P<db>\w+)/(?P<shot>\d+)/(?P<run>\d+)$')
+    r'^((?P<user>[\\\/\w]*)\/)?(?P<db>\w+)\/(?P<shot>\d+)\/(?P<run>\d+)$')
 
 
 def _patch_str_repr(obj: object):

--- a/tests/ids/test_imas_handler.py
+++ b/tests/ids/test_imas_handler.py
@@ -19,12 +19,33 @@ TEST_OUTPUT = (
     (getuser(), 'moo', 9234, 123),
 )
 
+TEST_STRINGS_localdb = (
+    '/user/directory/jet/1/2',
+    '/a/longer/user/directory/jet/123/456',
+)
+TEST_OUTPUT_localdb = (
+    ('/user/directory', 'jet', 1, 2),
+    ('/a/longer/user/directory', 'jet', 123, 456),
+)
+
 
 @pytest.mark.parametrize('string,expected', zip(TEST_STRINGS, TEST_OUTPUT))
 def test_from_string(string, expected):
     handle = ImasHandle.from_string(string)
 
     assert not handle.is_local_db
+    assert handle.user == expected[0]
+    assert handle.db == expected[1]
+    assert handle.shot == expected[2]
+    assert handle.run == expected[3]
+
+
+@pytest.mark.parametrize('string,expected',
+                         zip(TEST_STRINGS_localdb, TEST_OUTPUT_localdb))
+def test_from_string_localdb(string, expected):
+    handle = ImasHandle.from_string(string)
+
+    assert handle.is_local_db
     assert handle.user == expected[0]
     assert handle.db == expected[1]
     assert handle.shot == expected[2]


### PR DESCRIPTION
Handles loading local db paths from a string.

```python
>>> handle = ImasHandle.from_string('/my/directory/imasdb/jet/123/456')
>>> handle
ImasHandle(relative_location=None, user='/my/directory/imasdb', db='jet', shot=123, run=456)
>>> handle.is_local_db
True
```