### PR TITLE
Add option to customize axes in dashboard

### DIFF
--- a/src/duqtools/__init__.py
+++ b/src/duqtools/__init__.py
@@ -8,6 +8,7 @@ def fix_dependencies():
         'jetto_tools>=1.8.8',
         'scipy>=1.09',
         'jinja2>=3.0.0',
+        'typing_extensions>=4.5.0',
     ]
     import pkg_resources  # noqa
 

--- a/src/duqtools/_plot_utils.py
+++ b/src/duqtools/_plot_utils.py
@@ -86,7 +86,7 @@ def alt_line_chart(source: Union[pd.DataFrame, xr.Dataset],
         x=f'{x}:Q', y=f'{y}:Q', color=alt.Color('run:N'), tooltip='run')
 
     if max_slider != 0:
-        slider = alt.binding_range(name='Time index',
+        slider = alt.binding_range(name=f'{z} index',
                                    min=0,
                                    max=max_slider,
                                    step=1)
@@ -100,7 +100,7 @@ def alt_line_chart(source: Union[pd.DataFrame, xr.Dataset],
             band = band.transform_filter(select_step).interactive()
 
         first_run = source.iloc[0].run
-        slider = alt.binding_range(name='Reference time index',
+        slider = alt.binding_range(name=f'Reference {z} index',
                                    min=0,
                                    max=max_slider,
                                    step=1)
@@ -183,7 +183,7 @@ def alt_errorband_chart(source: Union[pd.DataFrame, xr.Dataset],
         band = band.add_params(select_step).transform_filter(
             select_step).interactive()
 
-        slider = alt.binding_range(name='Reference time index',
+        slider = alt.binding_range(name=f'Reference {z} index',
                                    min=0,
                                    max=max_slider,
                                    step=1)

--- a/src/duqtools/dashboard/Plotting.py
+++ b/src/duqtools/dashboard/Plotting.py
@@ -55,24 +55,34 @@ with st.sidebar:
         help=('Show standard deviation band around mean y-value.'),
     )
 
+    axes_opts = 'grid', 'data', 'time'
+    x_axis = st.selectbox('X axis', axes_opts, index=0)
+    y_axis = st.selectbox('Y axis', axes_opts, index=1)
+    z_axis = st.selectbox('Z axis', axes_opts, index=2)
+
 for variable in (var_lookup[var_name] for var_name in var_names):
     source, time_var, grid_var, data_var = get_dataset(
         handles, variable, include_error=show_errorbar)
 
     st.header(f'{grid_var} vs. {data_var}')
 
+    axes = {'time': time_var, 'grid': grid_var, 'data': data_var}
+    x_var = axes[x_axis]
+    y_var = axes[y_axis]
+    z_var = axes[z_axis]
+
     if aggregate_data:
-        chart = alt_errorband_chart(source, x=grid_var, y=data_var, z=time_var)
+        chart = alt_errorband_chart(source, x=x_var, y=y_var, z=z_var)
     else:
         chart = alt_line_chart(source,
-                               x=grid_var,
-                               y=data_var,
-                               z=time_var,
+                               x=x_var,
+                               y=y_var,
+                               z=z_var,
                                std=show_errorbar)
 
     st.altair_chart(chart, use_container_width=True)
 
-    if st.button('Save this chart', key=f'download_{grid_var}-{data_var}'):
-        fname = f'chart_{grid_var}-{data_var}.html'
+    if st.button('Save this chart', key=f'download_{x_var}-{y_var}'):
+        fname = f'chart_{x_var}-{y_var}.html'
         chart.save(fname)
         st.success(f'✔️ Wrote chart to "{fname}"')


### PR DESCRIPTION
This PR adds some more flexibility to customize the axes in the dashboard. It seems to work, but it needs to be tested on a dataset with more than 2 time steps.

Closes #450

## todo

- [ ] test on data set with more than 1 time step
- [ ] Consider just flipping grid<->time via checkbox