### PR TITLE
Prepare `imas2xarray` submodule

### DIFF
--- a/scripts/modify_imas_data.py
+++ b/scripts/modify_imas_data.py
@@ -10,4 +10,4 @@ core_profiles = target.get('core_profiles')
 
 core_profiles['profiles_1d/0/t_i_average'] *= 1.1
 
-core_profiles.sync(target)
+target.update_from(core_profiles)

--- a/src/duqtools/ids/_apply_model.py
+++ b/src/duqtools/ids/_apply_model.py
@@ -89,4 +89,4 @@ def _apply_ids(model: IDSOperation,
 
     if target_in:
         logger.info('Writing data entry: %s', target_in)
-        ids_mapping.sync(target_in)
+        target_in.update_from(ids_mapping)

--- a/src/duqtools/ids/_handle.py
+++ b/src/duqtools/ids/_handle.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, List, Sequence
 from pydantic import field_validator
 
 from ..operations import add_to_op_queue
-from ._copy import copy_ids_entry
+from ._copy import add_provenance_info, copy_ids_entry
 from ._imas import imas, imasdef
 from ._mapping import IDSMapping
 from ._rebase import squash_placeholders
@@ -374,3 +374,20 @@ class ImasHandle(ImasBaseModel):
             yield entry
         finally:
             entry.close()
+
+    def update_from(self, mapping: IDSMapping):
+        """Synchronize updated data back to IMAS db entry.
+
+        Shortcut for 'put' command.
+
+        Parameters
+        ----------
+        mapping : IDSMapping
+            Points to an IDS mapping of the data that should be written
+            to this handle.
+        """
+
+        add_provenance_info(handle=self)
+
+        with self.open() as db_entry:
+            mapping._ids.put(db_entry=db_entry)

--- a/src/duqtools/ids/_mapping.py
+++ b/src/duqtools/ids/_mapping.py
@@ -7,12 +7,9 @@ from typing import TYPE_CHECKING, Any, Sequence
 import numpy as np
 
 from ..schema import IDSVariableModel
-from ._copy import add_provenance_info
 
 if TYPE_CHECKING:
     import xarray as xr
-
-    from ._handle import ImasHandle
 
 INDEX_STR = '*'
 
@@ -182,22 +179,6 @@ class IDSMapping(Mapping):
             return len(self[key])
         except Exception:
             pass
-
-    def sync(self, target: ImasHandle):
-        """Synchronize updated data back to IMAS db entry.
-
-        Shortcut for 'put' command.
-
-        Parameters
-        ----------
-        target : ImasHandle
-            Points to an IMAS db entry of where the data should be written.
-        """
-
-        add_provenance_info(handle=target)
-
-        with target.open() as db_entry:
-            self._ids.put(db_entry=db_entry)
 
     def dive(self, val, path: list):
         """Recursively find the data fields.

--- a/src/duqtools/ids/_merge.py
+++ b/src/duqtools/ids/_merge.py
@@ -97,4 +97,4 @@ def merge_data(
             path_upper = path + '_error_upper'
             target_ids.write_array_in_parts(path_upper, std_data[name])
 
-        target_ids.sync(target)
+        target.update_from(target_ids)


### PR DESCRIPTION
This PR organizes the code so that we can split out the imas reader into its own package.
The goal of this PR is to prepare a submodule `duqtools.imas2xarray` that is fully isolated from the rest of the code. Then we can filter out that directory into its own library.

Addresses #672 