### PR TITLE
Fix kwmain lookup crash

### DIFF
--- a/src/duqtools/data/jetto_tools_lookup.json
+++ b/src/duqtools/data/jetto_tools_lookup.json
@@ -73,6 +73,6 @@
       "field": "KWMAIN"
     },
     "type": "str",
-    "dimension": "scalar"
+    "dimension": "vector"
   }
 }


### PR DESCRIPTION
KWMAIN should be a vector, not a scalar.

Closes #701 