### PR TITLE
Fix cli version crash for pypi installs

### DIFF
--- a/src/duqtools/cli.py
+++ b/src/duqtools/cli.py
@@ -561,7 +561,7 @@ def cli_version(**kwargs):
     try:
         repo = git.Repo(Path(__file__), search_parent_directories=True)
         sha = repo.head.object.hexsha
-    except (OSError, ValueError):
+    except BaseException:
         sha = '???'
 
     string += f' (rev: {sha})'


### PR DESCRIPTION
The git python library now raises `git.exc.InvalidGitRepositoryError: /home/stef/python/duqtools_test/.venv/lib/python3.12/site-packages/duqtools/cli.py` if run from a nonlocal isntall (i.e. pypi), which we didn't catch before.

Closes #700