### PR TITLE
Fix IMAS tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,3 +10,4 @@ def pytest_configure():
     pytest.TEST_DATA = Path(__file__).parent / 'test_data'
 
     os.environ['JETTO_LOOKUP'] = str(pytest.TEST_DATA / 'jetto_lookup.json')
+    os.environ['JINTRAC_IMAS_BACKEND'] = 'MDSPLUS'


### PR DESCRIPTION
https://github.com/duqtools/duqtools/commit/72e55220b50f3e2851a6acaf9af54dd7f4f2ec64 set the default to HDF5, but the `containerized_runs` are still mdsplus.